### PR TITLE
remove build status via CircleCI, since not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 # flytekit-java
 
 [![Lifecycle](https://img.shields.io/badge/lifecycle-alpha-a0c3d2.svg)](https://img.shields.io/badge/lifecycle-alpha-a0c3d2.svg)
-[![Build Status](https://img.shields.io/circleci/project/github/spotify/flytekit-java/master.svg)](https://circleci.com/gh/spotify/flytekit-java)
 
 Java/Scala library for easily authoring Flyte tasks and workflows.
 


### PR DESCRIPTION
Signed-off-by: Bruce Arctor <5032356+brucearctor@users.noreply.github.com>

https://github.com/flyteorg/flyte/issues/1256 

One way to solve ^^ 

This isn't the right solution if there is a CircleCI build somewhere (but it looks like that was removed)

