### PR TITLE
Revert to GITHUB_TOKEN for publishing jars

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,9 +30,6 @@ jobs:
         with:
           java-version: 11.0
           distribution: 'adopt'
-          server-id: snapshots
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
       - name: Verify with Maven
         if: ${{ github.ref != 'refs/heads/master' }}
         run: mvn --batch-mode verify
@@ -40,5 +37,4 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         run: mvn --batch-mode deploy -DpreparationGoals=clean -Ddockerfile.push
         env:
-          GITHUB_USERNAME: "${{ secrets.FLYTE_BOT_USERNAME }}"
-          GITHUB_TOKEN: "${{ secrets.FLYTE_BOT_PAT }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,6 @@ jobs:
         with:
           java-version: 11.0
           distribution: 'adopt'
-          server-id: snapshots
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
 
       - name: Setup git configuration
         run: |
@@ -43,5 +40,4 @@ jobs:
           mvn --batch-mode release:prepare  -DpreparationGoals=clean -DgenerateBackupPoms=false
           mvn --batch-mode release:perform  -DpreparationGoals=clean -Ddockerfile.push
         env:
-          GITHUB_USERNAME: "${{ secrets.FLYTE_BOT_USERNAME }}"
-          GITHUB_TOKEN: "${{ secrets.FLYTE_BOT_PAT }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# TL;DR
Use GITHUB_TOKEN for publishing jars to Github Packages. Also remove config related to the setup-java action to avoid reconfiguring the `settings.xml` in the build `~/.m2` directory

## Type
 - [x] Fix Build
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The current code specified a `snapshots` repo in the setup-java action, however the repository in the pom have the `github` as id, this is a mismatch and removing the `snapshots` will leave the default to be used.

See more in [Github Packages docs](https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven#publishing-packages-to-github-packages)
## Tracking Issue
## Follow-up issue
_NA_
