### PR TITLE
use log4j >= 2.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <grpc.version>1.27.2</grpc.version>
     <picocli.version>4.2.0</picocli.version>
     <protobuf.version>3.11.4</protobuf.version>
-    <sl4j.version>1.7.30</sl4j.version>
+    <sl4j.version>1.7.32</sl4j.version>
     <spotless.version>1.30.0</spotless.version>
     <spotbugs.excludeFilterFile>spotbugs-exclude.xml</spotbugs.excludeFilterFile>
     <error_prone.version>2.3.4</error_prone.version>
@@ -100,6 +100,13 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.15.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-bom</artifactId>


### PR DESCRIPTION
Pinning log4j the version to 2.15 to avoid the compromised versions
https://www.lunasec.io/docs/blog/log4j-zero-day/

## Type
 - [X] Fix security vulnerability
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Specified a log4j bom version to constrain sl4j for pulling in the version with the security vulnerability.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
