### PR TITLE
make version an auto-value property

### DIFF
--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkRemoteLaunchPlan.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkRemoteLaunchPlan.java
@@ -37,9 +37,7 @@ public abstract class SdkRemoteLaunchPlan<InputT, OutputT> extends SdkTransform 
   public abstract String name();
 
   @Nullable
-  public String version() {
-    return null;
-  }
+  public abstract String version();
 
   public abstract SdkType<InputT> inputs();
 
@@ -113,6 +111,8 @@ public abstract class SdkRemoteLaunchPlan<InputT, OutputT> extends SdkTransform 
     public abstract Builder<InputT, OutputT> project(String project);
 
     public abstract Builder<InputT, OutputT> name(String name);
+
+    public abstract Builder<InputT, OutputT> version(String version);
 
     public abstract Builder<InputT, OutputT> inputs(SdkType<InputT> inputs);
 


### PR DESCRIPTION
Signed-off-by: Babis Kiosidis <ckiosidis@gmail.com>
# TL;DR

The version should be an auto-value property.
Fixing this now so we don't have to worry about it later.
There is a comment to fix it in the SdkRemoteTask as well, but it breaks backwards compatibility

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
