### PR TITLE
Use memoryfilesystem >= 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
       <dependency>
         <groupId>com.github.marschall</groupId>
         <artifactId>memoryfilesystem</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
## _Read then delete this section_

Update memoryfilesystem to 2.3.0.

## Type
 - [X] Component Update
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

memoryfilesystem 2.2.0 has a vulnerable log4j2 version as a test dependency. This shouldn't affect users but may still show up in some reports or tools. memoryfilesystem 2.3.0 no longer has a vulnerable log4j2 version as a test dependency. In addition the pom is now [flattened](https://search.maven.org/artifact/com.github.marschall/memoryfilesystem/2.3.0/pom) meaning test dependencies like log4j2 will no longer show up for users.

This is very similar to #48.

## Tracking Issue

_NA_

## Follow-up issue
_NA_
