### PR TITLE
Bump grpc versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,14 @@
   <version>0.3.4-SNAPSHOT</version>
 
   <properties>
-    <auto-service.version>1.0-rc5</auto-service.version>
+    <auto-service.version>1.0-rc6</auto-service.version>
     <auto-value.version>1.8.2</auto-value.version>
-    <grpc.version>1.27.2</grpc.version>
+    <grpc.version>1.40.1</grpc.version>
     <!-- must be aligned with netty version -->
     <!-- see: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-    <netty.tcnative.version>2.0.26.Final</netty.tcnative.version>
+    <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
     <picocli.version>4.2.0</picocli.version>
-    <protobuf.version>3.16.1</protobuf.version>
+    <protobuf.version>3.18.2</protobuf.version>
     <sl4j.version>1.7.32</sl4j.version>
     <spotless.version>1.30.0</spotless.version>
     <spotbugs.excludeFilterFile>spotbugs-exclude.xml</spotbugs.excludeFilterFile>


### PR DESCRIPTION
# TL;DR
Bump gRPC version and related libraries to please maven enforcer.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin
 - [X] Housekeeping

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Maven enforcer ensures that the library versions are compatible one with another plus we have the test suit to confirm also that nothing is broken.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
