### PR TITLE
Release snapshots to maven central

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-prepare-release-${{ hashFiles('pom.xml') }}
+
       - name: Log in to Docker Hub
         if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/login-action@v1
@@ -24,17 +25,26 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.FLYTE_BOT_USERNAME }}
           password: ${{ secrets.FLYTE_BOT_PAT }}
+
       - name: Setup JDK 11
         uses: actions/setup-java@v2
-        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           java-version: 11.0
           distribution: 'adopt'
+          server-id: ossrh
+          server-username: ${{ secrets.SONATYPE_USERNAME }}
+          server-password: ${{ secrets.SONATYPE_PASSWORD }}
+          gpg-private-key: ${{ secrets.SONATYPE_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.SONATYPE_PASSPHRASE }}
+
       - name: Verify with Maven
         if: ${{ github.ref != 'refs/heads/master' }}
         run: mvn --batch-mode verify
+
       - name: Release snapshot with Maven
         if: ${{ github.ref == 'refs/heads/master' }}
         run: mvn --batch-mode deploy -DpreparationGoals=clean -Ddockerfile.push
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.SONATYPE_PASSPHRASE }}


### PR DESCRIPTION
# TL;DR
Release snapshots to maven central

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
After #55, master build is in a broken state as github repository configuration was removed and merges to master would release a snapshot. This PR change the github config used in the to release the snapshots is replaced with the config to release to maven central.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/#2086

## Follow-up issue
_NA_
