### PR TITLE
Bump scala-maven compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>4.3.1</version>
+          <version>4.5.6</version>
         </plugin>
         <plugin>
           <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
Signed-off-by: Julien Bisconti <julienb@spotify.com>

# TL;DR
Older version of the scala-maven compiler plugin uses compromised log4j. Bumping solves that issue

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
