### PR TITLE
Add building doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ To learn more about Flyte refer to:
  - [Flyte homepage](https://flyte.org)
  - [Flyte master repository](https://github.com/lyft/flyte)
 
+## Build from source
+
+It requires **Java 1.8 and Docker**
+
+```bash
+mvn clean verify
+
+# Inspect dependency tree
+mvn dependency:tree
+
+# Inspect tooling dependency tree
+mvn dependency:resolve-plugins
+
+```
+
 ## How to run examples
 
 We don't publish artifacts yet, but you can build examples yourself. 
@@ -54,3 +69,9 @@ $ scripts/jflyte register workflows \
   -v=$(git describe --always) \
   -cp=flytekit-examples/target/lib
 ```
+
+## Contributing 
+
+Run `mvn spotless:apply` before committing. 
+
+Also use `git commit --signoff "Commit message"` to comply with DCO. 


### PR DESCRIPTION
Signed-off-by: Julien Bisconti <julienb@spotify.com>

# TL;DR
Tricky dependency tracking because of tooling using log4j.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

At Spotify, compromised versions of log4j were removed from Artifactory. Log4j was not used in the project dependencies but in the build pipeline dependencies. In our case it was the scala-maven compiler plugin, see https://github.com/flyteorg/flytekit-java/pull/61.

By adding documentation on how to build the project, we want to make it easier to troubleshoot those problems without having specific knowledge of dependency resolution in various companies. 
