### PR TITLE
Write proto bytes to file

### DIFF
--- a/jflyte/src/main/java/org/flyte/jflyte/SerializeWorkflows.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/SerializeWorkflows.java
@@ -94,6 +94,7 @@ public class SerializeWorkflows implements Callable<Integer> {
       // ugly because spotbugs doesn't like try-with-resources
       try {
         fos = new FileOutputStream(new File(folder, filename));
+        bytes.writeTo(fos);
         fos.flush();
       } catch (IOException e) {
         throw new UncheckedIOException("failed to write to " + folder + "/" + filename, e);


### PR DESCRIPTION
# TL;DR
`jflyte serialize workflows` was creating empty files. Bytes were not written

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Fix and ran the command. Checked produced files.
