### PR TITLE
Release artifacts in maven central and formatting changes

### DIFF
--- a/flyteidl-protos/pom.xml
+++ b/flyteidl-protos/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 
@@ -39,13 +40,6 @@
     </dependency>
   </dependencies>
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2</version>
-      </extension>
-    </extensions>
     <plugins>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
@@ -75,7 +69,8 @@
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
-          <failOnWarning>false</failOnWarning> <!-- Generated proto classes produce warnings -->
+          <failOnWarning>false</failOnWarning>
+          <!-- Generated proto classes produce warnings -->
           <!-- The semantics of this option are reversed, see MCOMPILER-209. -->
           <useIncrementalCompilation>false</useIncrementalCompilation>
           <encoding>utf-8</encoding>
@@ -118,5 +113,12 @@
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.6.2</version>
+      </extension>
+    </extensions>
   </build>
 </project>

--- a/flytekit-api/pom.xml
+++ b/flytekit-api/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 

--- a/flytekit-examples-scala/pom.xml
+++ b/flytekit-examples-scala/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 
@@ -57,10 +58,10 @@
         <executions>
           <execution>
             <id>copy-compile</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
+            <phase>prepare-package</phase>
             <configuration>
               <outputDirectory>${project.build.directory}/lib</outputDirectory>
               <useBaseVersion>false</useBaseVersion>
@@ -101,10 +102,10 @@
         <executions>
           <execution>
             <id>attach-javadocs</id>
-            <phase>none</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>none</phase>
           </execution>
         </executions>
       </plugin>

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/AddQuestionTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/AddQuestionTask.scala
@@ -22,9 +22,8 @@ import org.flyte.flytekitscala.SdkScalaType
 case class AddQuestionTaskInput(greeting: String)
 case class AddQuestionTaskOutput(greeting: String)
 
-/**
-  * Example Flyte task that takes a greeting message as input, appends "How are you?", and outputs
-  * the result.
+/** Example Flyte task that takes a greeting message as input, appends "How are
+  * you?", and outputs the result.
   */
 class AddQuestionTask
     extends SdkRunnableTask(
@@ -32,12 +31,13 @@ class AddQuestionTask
       SdkScalaType[AddQuestionTaskOutput]
     ) {
 
-  /**
-    * Defines task behavior. This task takes a greeting message as the input, append it with " How
-    * are you?", and outputs a new greeting message.
+  /** Defines task behavior. This task takes a greeting message as the input,
+    * append it with " How are you?", and outputs a new greeting message.
     *
-    * @param input the greeting message
-    * @return the updated greeting message
+    * @param input
+    *   the greeting message
+    * @return
+    *   the updated greeting message
     */
   override def run(input: AddQuestionTaskInput): AddQuestionTaskOutput =
     AddQuestionTaskOutput(s"${input.greeting} How are you?")
@@ -45,11 +45,12 @@ class AddQuestionTask
 
 object AddQuestionTask {
 
-  /**
-    * Binds input data to this task
+  /** Binds input data to this task
     *
-    * @param greeting the input greeting message
-    * @return a transformed instance of this class with input data
+    * @param greeting
+    *   the input greeting message
+    * @return
+    *   a transformed instance of this class with input data
     */
   def apply(greeting: SdkBindingData): SdkTransform =
     new AddQuestionTask().withInput("greeting", greeting)

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/GreetTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/GreetTask.scala
@@ -22,19 +22,22 @@ import org.flyte.flytekitscala.SdkScalaType
 case class GreetTaskInput(name: String)
 case class GreetTaskOutput(greeting: String)
 
-/** Example Flyte task that takes a name as the input and outputs a simple greeting message. */
+/** Example Flyte task that takes a name as the input and outputs a simple
+  * greeting message.
+  */
 class GreetTask
     extends SdkRunnableTask(
       SdkScalaType[GreetTaskInput],
       SdkScalaType[GreetTaskOutput]
     ) {
 
-  /**
-    * Defines task behavior. This task takes a name as the input, wraps it in a welcome message, and
-    * outputs the message.
+  /** Defines task behavior. This task takes a name as the input, wraps it in a
+    * welcome message, and outputs the message.
     *
-    * @param input the name of the person to be greeted
-    * @return the welcome message
+    * @param input
+    *   the name of the person to be greeted
+    * @return
+    *   the welcome message
     */
   override def run(input: GreetTaskInput): GreetTaskOutput =
     GreetTaskOutput(s"Welcome, ${input.name}!")
@@ -42,11 +45,12 @@ class GreetTask
 
 object GreetTask {
 
-  /**
-    * Binds input data to this task
+  /** Binds input data to this task
     *
-    * @param name the input name
-    * @return a transformed instance of this class with input data
+    * @param name
+    *   the input name
+    * @return
+    *   a transformed instance of this class with input data
     */
   def apply(name: SdkBindingData): SdkTransform =
     new GreetTask().withInput("name", name)

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/WelcomeWorkflow.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/WelcomeWorkflow.scala
@@ -19,30 +19,29 @@ package org.flyte.examples.flytekitscala
 import org.flyte.flytekit.{SdkWorkflow, SdkWorkflowBuilder}
 
 /** Example workflow that takes a name and outputs a welcome message
-  * +--------------------------------+
-  * |        start of workflow       |
-  * |      input: name(string)       |
-  * +--------------+-----------------+
-  *                |
-  *                |
+  * |  start of workflow  |
+  * |:-------------------:|
+  * | input: name(string) |
+  * |
+  * |
   * +--------------v-----------------+
-  * |          GreetTask             |
-  * |      input: name(string)       |
-  * |      output: greeting(string)  |
-  * +--------------+-----------------+
-  *                |
-  *                |
+  * | GreetTask                |
+  * |:-------------------------|
+  * | input: name(string)      |
+  * | output: greeting(string) |
+  * |
+  * |
   * +--------------v-----------------+
-  * |        AddQuestionTask         |
-  * |      input: greeting(string)   |
-  * |      output: greeting(string)  |
-  * +--------------+-----------------+
-  *                |
-  *                |
+  * |     AddQuestionTask      |
+  * |:------------------------:|
+  * | input: greeting(string)  |
+  * | output: greeting(string) |
+  * |
+  * |
   * +--------------v-----------------+
-  * |       end of workflow          |
-  * |     output: greeting(string)   |
-  * +--------------------------------+
+  * | end of workflow          |
+  * |:-------------------------|
+  * | output: greeting(string) |
   */
 class WelcomeWorkflow extends SdkWorkflow {
 

--- a/flytekit-examples/pom.xml
+++ b/flytekit-examples/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 
@@ -69,10 +70,10 @@
         <executions>
           <execution>
             <id>copy-compile</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
+            <phase>prepare-package</phase>
             <configuration>
               <outputDirectory>${project.build.directory}/lib</outputDirectory>
               <useBaseVersion>false</useBaseVersion>

--- a/flytekit-jackson/pom.xml
+++ b/flytekit-jackson/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 
@@ -34,8 +35,8 @@
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>2.11.0</version>
-        <scope>import</scope>
         <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/flytekit-java/pom.xml
+++ b/flytekit-java/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 

--- a/flytekit-local-engine/pom.xml
+++ b/flytekit-local-engine/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 

--- a/flytekit-scala-tests/pom.xml
+++ b/flytekit-scala-tests/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 

--- a/flytekit-scala_2.12/pom.xml
+++ b/flytekit-scala_2.12/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 
@@ -67,8 +68,6 @@
   </dependencies>
 
   <build>
-    <sourceDirectory>../flytekit-scala_2.13/src/main/scala</sourceDirectory>
-    <testSourceDirectory>../flytekit-scala_2.13/src/test/scala</testSourceDirectory>
     <plugins>
       <plugin>
         <groupId>net.alchim31.maven</groupId>
@@ -97,5 +96,7 @@
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
     </plugins>
+    <sourceDirectory>../flytekit-scala_2.13/src/main/scala</sourceDirectory>
+    <testSourceDirectory>../flytekit-scala_2.13/src/test/scala</testSourceDirectory>
   </build>
 </project>

--- a/flytekit-scala_2.13/pom.xml
+++ b/flytekit-scala_2.13/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkScalaType.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkScalaType.scala
@@ -25,7 +25,9 @@ import org.flyte.flytekit.SdkType
 import scala.annotation.implicitNotFound
 import scala.collection.JavaConverters._
 
-/** Type class to map between Flyte `Variable` and `Literal` and Scala case classes. */
+/** Type class to map between Flyte `Variable` and `Literal` and Scala case
+  * classes.
+  */
 sealed trait SdkScalaType[T]
 
 // products (e.g. case classes and tuples) can map into literal map
@@ -158,8 +160,8 @@ object SdkScalaType {
       _.scalar().primitive().duration()
     )
 
-  implicit def collectionLiteralType[T](
-      implicit sdkLiteral: SdkScalaLiteralType[T]
+  implicit def collectionLiteralType[T](implicit
+      sdkLiteral: SdkScalaLiteralType[T]
   ): SdkScalaLiteralType[List[T]] = {
     new SdkScalaLiteralType[List[T]] {
 
@@ -183,8 +185,8 @@ object SdkScalaType {
     }
   }
 
-  implicit def mapLiteralType[T](
-      implicit sdkLiteral: SdkScalaLiteralType[T]
+  implicit def mapLiteralType[T](implicit
+      sdkLiteral: SdkScalaLiteralType[T]
   ): SdkScalaLiteralType[Map[String, T]] = {
     new SdkScalaLiteralType[Map[String, T]] {
 
@@ -193,7 +195,9 @@ object SdkScalaType {
 
       override def toLiteral(values: Map[String, T]): Literal = {
         Literal.ofMap(
-          values.map { case (key, value) => key -> sdkLiteral.toLiteral(value) }.asJava
+          values.map { case (key, value) =>
+            key -> sdkLiteral.toLiteral(value)
+          }.asJava
         )
       }
 

--- a/flytekit-testing/pom.xml
+++ b/flytekit-testing/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 
@@ -81,8 +82,8 @@
     <dependency>
       <groupId>org.flyte</groupId>
       <artifactId>jflyte-build</artifactId>
-      <optional>true</optional>
       <scope>test</scope>
+      <optional>true</optional>
     </dependency>
 
     <!-- test -->
@@ -116,10 +117,10 @@
         <executions>
           <execution>
             <id>copy-compile</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
+            <phase>prepare-package</phase>
             <configuration>
               <outputDirectory>${project.build.directory}/lib</outputDirectory>
               <useBaseVersion>false</useBaseVersion>

--- a/jflyte-api/pom.xml
+++ b/jflyte-api/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 

--- a/jflyte-aws/pom.xml
+++ b/jflyte-aws/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 

--- a/jflyte-build/pom.xml
+++ b/jflyte-build/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 

--- a/jflyte-google-cloud/pom.xml
+++ b/jflyte-google-cloud/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 
@@ -25,13 +26,13 @@
 
   <artifactId>jflyte-google-cloud</artifactId>
 
+  <name>JFlyte - Gcloud Filesystem and IdToken extension</name>
+  <description>Stages jars in GCS.</description>
+
   <properties>
     <mockito.version>3.3.3</mockito.version>
     <junit.version>5.7.0</junit.version>
   </properties>
-
-  <name>JFlyte - Gcloud Filesystem and IdToken extension</name>
-  <description>Stages jars in GCS.</description>
 
   <dependencyManagement>
     <dependencies>
@@ -85,8 +86,8 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
       <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -103,8 +104,8 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
       <version>${mockito.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/jflyte/pom.xml
+++ b/jflyte/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 
@@ -76,7 +77,7 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
     </dependency>
-    
+
     <!-- runtime -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/jflyte/src/main/java/org/flyte/jflyte/ExecuteDynamicWorkflow.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/ExecuteDynamicWorkflow.java
@@ -131,8 +131,7 @@ public class ExecuteDynamicWorkflow implements Callable<Integer> {
               ProjectClosure.createTaskTemplates(
                   executionConfig, runnableTasks, dynamicWorkflowTasks),
               template ->
-                  template
-                      .toBuilder()
+                  template.toBuilder()
                       .custom(ProjectClosure.merge(template.custom(), custom))
                       .build());
 

--- a/jflyte/src/main/java/org/flyte/jflyte/WorkflowNodeVisitor.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/WorkflowNodeVisitor.java
@@ -52,8 +52,7 @@ class WorkflowNodeVisitor {
   }
 
   WorkflowNode visitWorkflowNode(WorkflowNode workflowNode) {
-    return workflowNode
-        .toBuilder()
+    return workflowNode.toBuilder()
         .reference(visitWorkflowNodeReference(workflowNode.reference()))
         .build();
   }
@@ -63,8 +62,7 @@ class WorkflowNodeVisitor {
   }
 
   IfElseBlock visitIfElseBlock(IfElseBlock ifElse) {
-    return ifElse
-        .toBuilder()
+    return ifElse.toBuilder()
         .case_(visitIfBlock(ifElse.case_()))
         .other(ifElse.other().stream().map(this::visitIfBlock).collect(toUnmodifiableList()))
         .elseNode(ifElse.elseNode() != null ? visitNode(ifElse.elseNode()) : null)

--- a/jflyte/src/test/java/org/flyte/jflyte/ProtoUtilTest.java
+++ b/jflyte/src/test/java/org/flyte/jflyte/ProtoUtilTest.java
@@ -500,8 +500,7 @@ class ProtoUtilTest {
   void shouldSerializeWorkflowTemplate() {
     Node nodeA = createNode("a").toBuilder().upstreamNodeIds(singletonList("b")).build();
     Node nodeB =
-        createNode("b")
-            .toBuilder()
+        createNode("b").toBuilder()
             .metadata(
                 NodeMetadata.builder()
                     .name("fancy-b")

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2021 Flyte Authors.
 
@@ -19,35 +20,30 @@
 
   <groupId>org.flyte</groupId>
   <artifactId>flytekit-parent</artifactId>
+  <version>0.3.10-SNAPSHOT</version>
 
   <packaging>pom</packaging>
-  <version>0.3.10-SNAPSHOT</version>
 
   <name>Flytekit Java</name>
   <description>Flytekit Java is the Java/Scala SDK built on top of Flyte.</description>
   <url>https://github.com/flyteorg/flytekit-java</url>
 
-  <properties>
-    <auto-service.version>1.0-rc6</auto-service.version>
-    <auto-value.version>1.8.2</auto-value.version>
-    <grpc.version>1.40.1</grpc.version>
-    <!-- must be aligned with netty version -->
-    <!-- see: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-    <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
-    <picocli.version>4.2.0</picocli.version>
-    <protobuf.version>3.18.2</protobuf.version>
-    <sl4j.version>1.7.32</sl4j.version>
-    <spotless.version>1.30.0</spotless.version>
-    <spotbugs.excludeFilterFile>spotbugs-exclude.xml</spotbugs.excludeFilterFile>
-    <error_prone.version>2.10.0</error_prone.version>
-    <!-- Using the error-prone-javac is required when running on JDK 8 -->
-    <error_prone.javac.version>9+181-r4173-1</error_prone.javac.version>
-    <junit.version>5.6.2</junit.version>
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
-    <!-- has to be one liner, or errorprone doesn't work -->
-    <error-prone-base-config><![CDATA[-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/generated-(test-)?sources/.*]]></error-prone-base-config>
-    <error-prone-additional-args>-Xep:AutoValueImmutableFields:OFF -Xep:Var:ERROR</error-prone-additional-args>
-  </properties>
+  <developers>
+    <developer>
+      <name>flytekit</name>
+      <email>admin@flyte.org</email>
+      <organization>Flyte</organization>
+      <organizationUrl>https://flyte.org</organizationUrl>
+    </developer>
+  </developers>
 
   <modules>
     <module>flytekit-api</module>
@@ -68,6 +64,46 @@
     <module>jflyte-google-cloud</module>
     <module>integration-tests</module>
   </modules>
+
+  <scm>
+    <connection>scm:git:https://github.com/flyteorg/flytekit-java.git</connection>
+    <developerConnection>scm:git:https://github.com/flyteorg/flytekit-java.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/flyteorg/flytekit-java</url>
+  </scm>
+
+  <distributionManagement>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <properties>
+    <auto-service.version>1.0-rc6</auto-service.version>
+    <auto-value.version>1.8.2</auto-value.version>
+    <grpc.version>1.40.1</grpc.version>
+    <!-- must be aligned with netty version -->
+    <!-- see: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
+    <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
+    <picocli.version>4.2.0</picocli.version>
+    <protobuf.version>3.18.2</protobuf.version>
+    <sl4j.version>1.7.32</sl4j.version>
+    <spotless.version>2.21.0</spotless.version>
+    <spotbugs.excludeFilterFile>spotbugs-exclude.xml</spotbugs.excludeFilterFile>
+    <error_prone.version>2.10.0</error_prone.version>
+    <!-- Using the error-prone-javac is required when running on JDK 8 -->
+    <error_prone.javac.version>9+181-r4173-1</error_prone.javac.version>
+    <junit.version>5.6.2</junit.version>
+
+    <!-- has to be one liner, or errorprone doesn't work -->
+    <error-prone-base-config><![CDATA[-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/generated-(test-)?sources/.*]]></error-prone-base-config>
+    <error-prone-additional-args>-Xep:AutoValueImmutableFields:OFF -Xep:Var:ERROR</error-prone-additional-args>
+  </properties>
 
   <dependencyManagement>
     <dependencies>
@@ -229,107 +265,29 @@
     </dependencies>
   </dependencyManagement>
 
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <scm>
-    <connection>scm:git:https://github.com/flyteorg/flytekit-java.git</connection>
-    <developerConnection>scm:git:https://github.com/flyteorg/flytekit-java.git
-    </developerConnection>
-    <url>https://github.com/flyteorg/flytekit-java</url>
-    <tag>HEAD</tag>
-  </scm>
-
-  <developers>
-    <developer>
-      <name>flytekit</name>
-      <email>admin@flyte.org</email>
-      <organization>Flyte</organization>
-      <organizationUrl>https://flyte.org</organizationUrl>
-    </developer>
-  </developers>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <repositories>
     <repository>
-      <id>apache.snapshots</id>
-      <name>Apache Development Snapshot Repository</name>
-      <url>https://repository.apache.org/content/repositories/snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+      <id>apache.snapshots</id>
+      <name>Apache Development Snapshot Repository</name>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
     </repository>
     <repository>
-      <id>ossrh</id>
-      <name>Sonatype OSS</name>
-      <url>https://oss.sonatype.org/content/repositories/releases/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+      <id>ossrh</id>
+      <name>Sonatype OSS</name>
+      <url>https://oss.sonatype.org/content/repositories/releases/</url>
     </repository>
   </repositories>
 
   <build>
-    <plugins>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.0-M4</version>
-        <configuration>
-          <preparationGoals>clean spotless:apply</preparationGoals>
-          <autoVersionSubmodules>true</autoVersionSubmodules>
-          <allowTimestampedSnapshots>false</allowTimestampedSnapshots>
-          <tagNameFormat>@{project.version}</tagNameFormat>
-        </configuration>
-      </plugin>
-    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -404,11 +362,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */
-]]></content>
+ */]]></content>
               </licenseHeader>
               <googleJavaFormat>
-                <version>1.7</version>
+                <version>1.8</version>
                 <style>GOOGLE</style>
               </googleJavaFormat>
               <removeUnusedImports />
@@ -434,13 +391,10 @@
   KIND, either express or implied.  See the License for the
   specific language governing permissions and limitations
   under the License.
--->
-]]></content>
+-->]]></content>
               </licenseHeader>
               <eclipse>
-                <file>
-                  ${maven.multiModuleProjectDirectory}/spotless.xmlformat.prefs
-                </file>
+                <file>${maven.multiModuleProjectDirectory}/spotless.xmlformat.prefs</file>
               </eclipse>
             </xml>
             <scala>
@@ -463,14 +417,34 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */
-]]></content>
+ */]]></content>
               </licenseHeader>
             </scala>
+            <pom>
+              <!-- These are the defaults, you can override if you want -->
+              <includes>
+                <include>pom.xml</include>
+              </includes>
+
+              <sortPom>
+                <encoding>UTF-8</encoding>
+                <lineSeparator>${line.separator}</lineSeparator>
+                <expandEmptyElements>false</expandEmptyElements>
+                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+                <keepBlankLines>true</keepBlankLines>
+                <nrOfIndentSpace>2</nrOfIndentSpace>
+                <indentBlankLines>false</indentBlankLines>
+                <indentSchemaLocation>false</indentSchemaLocation>
+                <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
+                <sortProperties>false</sortProperties>
+                <sortModules>false</sortModules>
+                <sortExecutions>false</sortExecutions>
+              </sortPom>
+            </pom>
+
             <formats>
               <format>
                 <includes>
-                  <include>**/pom.xml</include>
                   <include>**/src/**.xml</include>
                 </includes>
                 <!-- Files must end with a newline -->
@@ -480,10 +454,10 @@
           </configuration>
           <executions>
             <execution>
-              <phase>verify</phase>
               <goals>
                 <goal>check</goal>
               </goals>
+              <phase>verify</phase>
             </execution>
           </executions>
         </plugin>
@@ -514,10 +488,10 @@
           </configuration>
           <executions>
             <execution>
-              <phase>verify</phase>
               <goals>
                 <goal>check</goal>
               </goals>
+              <phase>verify</phase>
             </execution>
           </executions>
         </plugin>
@@ -575,10 +549,10 @@
           </configuration>
           <executions>
             <execution>
-              <phase>verify</phase>
               <goals>
                 <goal>check</goal>
               </goals>
+              <phase>verify</phase>
             </execution>
           </executions>
         </plugin>
@@ -595,17 +569,15 @@
               <!-- Generated during build to shade dependencies -->
               <exclude>**/dependency-reduced-pom.xml</exclude>
               <exclude>**/target/checkstyle-result.xml</exclude>
-              <exclude>
-                **/target/javadoc-bundle-options/javadoc-options-javadoc-resources.xml
-              </exclude>
+              <exclude>**/target/javadoc-bundle-options/javadoc-options-javadoc-resources.xml</exclude>
             </excludes>
           </configuration>
           <executions>
             <execution>
-              <phase>verify</phase>
               <goals>
                 <goal>check</goal>
               </goals>
+              <phase>verify</phase>
             </execution>
           </executions>
         </plugin>
@@ -624,6 +596,9 @@
           <executions>
             <execution>
               <id>enforce</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
               <configuration>
                 <rules>
                   <requireMavenVersion>
@@ -632,9 +607,6 @@
                   <requireUpperBoundDeps />
                 </rules>
               </configuration>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
             </execution>
           </executions>
         </plugin>
@@ -645,31 +617,22 @@
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.2.0</version>
-          <executions>
-            <execution>
-              <id>default-jar</id>
-              <phase>prepare-package</phase>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-            </execution>
-          </executions>
           <configuration>
             <outputDirectory>${project.build.directory}/lib</outputDirectory>
           </configuration>
+          <executions>
+            <execution>
+              <id>default-jar</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+              <phase>prepare-package</phase>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.1.2</version>
-          <executions>
-            <execution>
-              <id>copy-dependencies</id>
-              <phase>package</phase>
-              <goals>
-                <goal>copy-dependencies</goal>
-              </goals>
-            </execution>
-          </executions>
           <configuration>
             <outputDirectory>${project.build.directory}/lib</outputDirectory>
             <useBaseVersion>false</useBaseVersion>
@@ -677,9 +640,60 @@
             <overWriteSnapshots>true</overWriteSnapshots>
             <includeScope>runtime</includeScope>
           </configuration>
+          <executions>
+            <execution>
+              <id>copy-dependencies</id>
+              <goals>
+                <goal>copy-dependencies</goal>
+              </goals>
+              <phase>package</phase>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>3.0.0-M4</version>
+        <configuration>
+          <preparationGoals>clean spotless:apply</preparationGoals>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <allowTimestampedSnapshots>false</allowTimestampedSnapshots>
+          <tagNameFormat>@{project.version}</tagNameFormat>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>
@@ -695,10 +709,10 @@
             <executions>
               <execution>
                 <id>sign-artifacts</id>
-                <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <phase>verify</phase>
                 <configuration>
                   <gpgArguments>
                     <arg>--batch</arg>
@@ -726,6 +740,10 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.3.1</version>
+            <configuration>
+              <source>8</source>
+              <doclint>all,-missing</doclint>
+            </configuration>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -734,10 +752,6 @@
                 </goals>
               </execution>
             </executions>
-            <configuration>
-              <source>8</source>
-              <doclint>all,-missing</doclint>
-            </configuration>
           </plugin>
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
@@ -779,8 +793,7 @@
               <configuration>
                 <compilerArgs combine.children="append">
                   <arg>-XDcompilePolicy=simple</arg>
-                  <arg>${error-prone-base-config} ${error-prone-additional-args}
-                  </arg>
+                  <arg>${error-prone-base-config} ${error-prone-additional-args}</arg>
                 </compilerArgs>
               </configuration>
             </plugin>
@@ -788,7 +801,7 @@
         </pluginManagement>
       </build>
     </profile>
-    
+
     <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
     <profile>
       <id>jdk8</id>
@@ -804,9 +817,7 @@
               <configuration>
                 <fork>true</fork>
                 <compilerArgs combine.children="append">
-                  <arg>
-                    -J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${error_prone.javac.version}/javac-${error_prone.javac.version}.jar
-                  </arg>
+                  <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${error_prone.javac.version}/javac-${error_prone.javac.version}.jar</arg>
                 </compilerArgs>
               </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -761,16 +761,7 @@
             <configuration>
               <serverId>ossrh</serverId>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-              <!-- TODO: remove once we have it sort out the release to maven central -->
-              <!-- manually inspect the staging repository in the Nexus Repository Manager and trigger a release of the
-               staging repository later with
-
-               mvn nexus-staging:release
-
-               If you find something went wrong you can drop the staging repository with
-
-               mvn nexus-staging:drop -->
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
# TL;DR
* Tell the release plugin to not stage the artifacts in maven central, but release it right away. 
* Configure spotless to format poms to not conflict with the release plugin.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Currently artifacts are staged by maven central for manual inspection. And then doing `mvn nexus-staging:release` would release it. However I can verify it anyway, so lets release it and "test in production".

Also previous spotless config for poms had a conflict with the release:plugin. The release plugin changed from multipline `project` tag to a single line.
```diff
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
```
It is actually a [bug](https://issues.apache.org/jira/browse/MRELEASE-1008) in the release plugin. As no attachment to multiline `project` is held so this PR changes the format of spotless to produce single line `project` in poms.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2086

## Follow-up issue
_NA_
