### PR TITLE
automate sonatype release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
 
           mvn --batch-mode release:prepare -DgenerateBackupPoms=false
           echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-          mvn --batch-mode release:perform -Ddockerfile.push -Prelease
+          mvn --batch-mode release:perform nexus-staging:release -Ddockerfile.push -Prelease
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
use the nexus-staging plugin to automate the deployment

# TL;DR

The jars are successfully pushed to the repository but we need to login to "manually" release them. 
Based on these docs i think we should be able to use the nexus plugin to avoid that manual step:

https://central.sonatype.org/publish/publish-maven/#manually-releasing-the-deployment-to-the-central-repository
https://central.sonatype.org/publish/release/#locate-and-examine-your-staging-repository

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
