### PR TITLE
Add JAVA_TOOL_OPTIONS env to task template

### DIFF
--- a/jflyte/src/main/java/org/flyte/jflyte/ProtoUtil.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/ProtoUtil.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import static org.flyte.jflyte.MoreCollectors.mapValues;
 import static org.flyte.jflyte.MoreCollectors.toUnmodifiableList;
 import static org.flyte.jflyte.MoreCollectors.toUnmodifiableMap;
+import static org.flyte.jflyte.QuantityUtil.isValidQuantity;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -112,16 +113,6 @@ class ProtoUtil {
   private static final Instant DATETIME_MAX =
       ISO_DATE_TIME.parse("9999-12-31T23:59:59.999999999Z", Instant::from);
   private static final Pattern DNS_1123_REGEXP = Pattern.compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$");
-  private static final String DIGITS = "(\\d+(\\.(\\d+)?)?|\\.(\\d+))";
-  private static final String SIGNED_NUMBER = "([+-])?" + DIGITS;
-  private static final String POSITIVE_NUMBER = "([+])?" + DIGITS;
-  private static final String DECIMAL_EXPONENT = "[eE]" + SIGNED_NUMBER;
-  private static final String BINARY_SI = "Ki|Mi|Gi|Ti|Pi|Ei";
-  private static final String DECIMAL_SI = "m||k|M|G|T|P|E";
-  private static final String SUFFIX =
-      "(" + BINARY_SI + "|" + DECIMAL_SI + "|" + DECIMAL_EXPONENT + ")";
-  private static final Pattern QUANTITY_PATTERN =
-      Pattern.compile("^" + POSITIVE_NUMBER + SUFFIX + "$");
 
   static final String RUNTIME_FLAVOR = "java";
   static final String RUNTIME_VERSION = "0.0.1";
@@ -634,10 +625,6 @@ class ProtoUtil {
                   .setValue(value)
                   .build());
         });
-  }
-
-  private static boolean isValidQuantity(String value) {
-    return QUANTITY_PATTERN.matcher(value).matches();
   }
 
   private static Tasks.Resources.ResourceName serialize(Resources.ResourceName name) {

--- a/jflyte/src/main/java/org/flyte/jflyte/QuantityUtil.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/QuantityUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.jflyte;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class QuantityUtil {
+  private static final String DIGITS = "(\\d+(\\.(\\d+)?)?|\\.(\\d+))";
+  private static final String POSITIVE_NUMBER = "(?<number>([+])?" + DIGITS + ")";
+  private static final String SIGNED_NUMBER = "([+-])?" + DIGITS;
+  private static final String DECIMAL_EXPONENT = "(?<decimalexp>[eE]" + SIGNED_NUMBER + ")";
+  private static final String BINARY_SI = "(?<binarysi>Ki|Mi|Gi|Ti|Pi|Ei)";
+  private static final String DECIMAL_SI = "(?<decimalsi>m||k|M|G|T|P|E)";
+  private static final String SUFFIX =
+      "(?<suffix>" + BINARY_SI + "|" + DECIMAL_SI + "|" + DECIMAL_EXPONENT + ")";
+  private static final Pattern QUANTITY_PATTERN =
+      Pattern.compile("^" + POSITIVE_NUMBER + SUFFIX + "$");
+
+  static boolean isValidQuantity(String value) {
+    return QUANTITY_PATTERN.matcher(value).matches();
+  }
+
+  static String asJavaQuantity(String value) {
+    Matcher matcher = QUANTITY_PATTERN.matcher(value);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException("Couldn't convert to Java quantity: " + value);
+    }
+
+    double number = Double.parseDouble(matcher.group("number"));
+    String binarySi = matcher.group("binarysi");
+    String decimalSi = matcher.group("decimalsi");
+    String decimalExp = matcher.group("decimalexp");
+    if (binarySi != null) {
+      return javaQuantityFromBinarySi(number, binarySi);
+    } else if (decimalSi != null) {
+      return javaQuantityFromDecimalSi(number, decimalSi);
+    } else { // if (decimalexp != null) {
+      return javaQuantityFromDecimalExp(number, decimalExp);
+    }
+  }
+
+  private static String javaQuantityFromBinarySi(double origNumber, String binarySiUnit) {
+    return roundUp(origNumber) + binarySiUnit.substring(0, 1);
+  }
+
+  private static String javaQuantityFromDecimalSi(double origNumber, String decimalSiUnit) {
+    // approximate decimal units to binary units to make it simple
+    if (decimalSiUnit.equals("m")) {
+      return String.valueOf(roundUp(origNumber / 1000));
+    } else {
+      return roundUp(origNumber) + decimalSiUnit;
+    }
+  }
+
+  private static String javaQuantityFromDecimalExp(double origNumber, String decimalExp) {
+    double exp = Double.parseDouble(decimalExp.replaceAll("[eE]", ""));
+    return String.valueOf(roundUp(origNumber * Math.pow(10, exp)));
+  }
+
+  private static long roundUp(double origNumber) {
+    return (long) Math.ceil(origNumber);
+  }
+}

--- a/jflyte/src/test/java/org/flyte/jflyte/ProjectClosureTest.java
+++ b/jflyte/src/test/java/org/flyte/jflyte/ProjectClosureTest.java
@@ -16,7 +16,9 @@
  */
 package org.flyte.jflyte;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static org.flyte.api.v1.Resources.ResourceName.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -36,6 +38,7 @@ import org.flyte.api.v1.ComparisonExpression;
 import org.flyte.api.v1.Container;
 import org.flyte.api.v1.IfBlock;
 import org.flyte.api.v1.IfElseBlock;
+import org.flyte.api.v1.KeyValuePair;
 import org.flyte.api.v1.LaunchPlan;
 import org.flyte.api.v1.LaunchPlanIdentifier;
 import org.flyte.api.v1.Literal;
@@ -413,6 +416,7 @@ public class ProjectClosureTest {
     assertNotNull(container);
     assertThat(container.image(), equalTo(image));
     assertThat(container.resources(), equalTo(expectedResources));
+    assertThat(container.env(), equalTo(emptyList()));
     assertThat(
         result.interface_(),
         equalTo(
@@ -428,11 +432,12 @@ public class ProjectClosureTest {
   @Test
   public void testCreateTaskTemplateForRunnableTaskWithResources() {
     // given
-    Map<Resources.ResourceName, String> resourceValues = new HashMap<>();
-    resourceValues.put(Resources.ResourceName.MEMORY, "0.5Gi");
-
     Resources expectedResources =
-        Resources.builder().limits(resourceValues).requests(resourceValues).build();
+        Resources.builder()
+            .limits(ImmutableMap.of(MEMORY, "16G"))
+            .requests(ImmutableMap.of(CPU, "4"))
+            .build();
+
     RunnableTask task = createRunnableTask(expectedResources);
     String image = "my-image";
 
@@ -444,6 +449,9 @@ public class ProjectClosureTest {
     assertNotNull(container);
     assertThat(container.image(), equalTo(image));
     assertThat(container.resources(), equalTo(expectedResources));
+    assertThat(
+        container.env(),
+        equalTo(ImmutableList.of(KeyValuePair.of("JAVA_TOOL_OPTIONS", "-Xmx16G"))));
     assertThat(
         result.interface_(),
         equalTo(

--- a/jflyte/src/test/java/org/flyte/jflyte/QuantityUtilTest.java
+++ b/jflyte/src/test/java/org/flyte/jflyte/QuantityUtilTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.jflyte;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class QuantityUtilTest {
+  @ParameterizedTest
+  @ValueSource(strings = {"4", "2.3", "+1", "2Ki", "4m", "5e-3", "3E6"})
+  void shouldIdentifyValidQuantities(String quantity) {
+    assertTrue(QuantityUtil.isValidQuantity(quantity));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "+-1", "not a number"})
+  void shouldNotIdentifyInvalidQuantities(String quantity) {
+    assertFalse(QuantityUtil.isValidQuantity(quantity));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"4,4", "2.3,3", "+1,1", "2Ki,2K", "4m,1", "5e-3,1", "3E6,3000000"})
+  void shouldConvertQuantitiesToJava(String quantity, String expected) {
+    assertEquals(expected, QuantityUtil.asJavaQuantity(quantity));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenConvertingInvalidQuantities() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> QuantityUtil.asJavaQuantity("not a quantity"));
+
+    assertEquals("Couldn't convert to Java quantity: not a quantity", ex.getMessage());
+  }
+}


### PR DESCRIPTION
# TL;DR
Add JAVA_TOOL_OPTIONS env to task template to account accomodate for the task's resource limit.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [X] Any pending items have an associated Issue

## Complete description
Propagate the Resource Memory limit into env `JAVA_TOOL_OPTIONS=-Xmx` in the task template so that the jvm running the java task picks this up and the the upper limit accordingly.

As described in the [java documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars002.html), `JAVA_TOOL_OPTIONS` is picked up by the `java` command to inject options as if they were written in the command line.

The parameter `-Xmx<size>[g|G|m|M|k|K]` described [here](https://docs.oracle.com/cd/E13150_01/jrockit_jvm/jrockit/jrdocs/refman/optionX.html) is used to specify the max size for the memory heap.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2285

## Follow-up issue
https://github.com/flyteorg/flyte/issues/2286
