### PR TITLE
Add Container task

### DIFF
--- a/flytekit-api/src/main/java/org/flyte/api/v1/ContainerTask.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/ContainerTask.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.api.v1;
+
+import static java.util.Collections.emptyMap;
+
+import java.util.List;
+import java.util.Locale;
+
+/** Building block for tasks that execute arbitrary containers. */
+public interface ContainerTask {
+
+  /** Specifies task name. */
+  String getName();
+
+  /** Specifies container image. */
+  String getImage();
+
+  /** Specifies command line arguments for container command. */
+  List<String> getArgs();
+
+  /** Specifies container command. Example: {@code List.of("java", "-Xmx1G")}. */
+  List<String> getCommand();
+
+  /** Specifies container environment variables. */
+  List<KeyValuePair> getEnv();
+
+  default String getType() {
+    return "raw-container".toLowerCase(Locale.ROOT);
+  }
+
+  TypedInterface getInterface();
+
+  /** Specifies container resource requests. */
+  default Resources getResources() {
+    return Resources.builder().build();
+  }
+
+  /** Specifies task retry policy. */
+  RetryStrategy getRetries();
+
+  /** Specifies custom container parameters. */
+  default Struct getCustom() {
+    return Struct.of(emptyMap());
+  }
+}

--- a/flytekit-api/src/main/java/org/flyte/api/v1/ContainerTask.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/ContainerTask.java
@@ -19,7 +19,6 @@ package org.flyte.api.v1;
 import static java.util.Collections.emptyMap;
 
 import java.util.List;
-import java.util.Locale;
 
 /** Building block for tasks that execute arbitrary containers. */
 public interface ContainerTask {
@@ -40,7 +39,7 @@ public interface ContainerTask {
   List<KeyValuePair> getEnv();
 
   default String getType() {
-    return "raw-container".toLowerCase(Locale.ROOT);
+    return "raw-container";
   }
 
   TypedInterface getInterface();

--- a/flytekit-api/src/main/java/org/flyte/api/v1/ContainerTaskRegistrar.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/ContainerTaskRegistrar.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.api.v1;
+
+/** A registrar that creates {@link ContainerTask} instances. */
+public abstract class ContainerTaskRegistrar implements Registrar<TaskIdentifier, ContainerTask> {}

--- a/flytekit-examples/src/main/java/org/flyte/examples/ContainerLaunchPlanRegistry.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/ContainerLaunchPlanRegistry.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.examples;
+
+import com.google.auto.service.AutoService;
+import org.flyte.flytekit.SdkLaunchPlan;
+import org.flyte.flytekit.SdkLaunchPlanRegistry;
+import org.flyte.flytekit.SimpleSdkLaunchPlanRegistry;
+
+@AutoService(SdkLaunchPlanRegistry.class)
+public class ContainerLaunchPlanRegistry extends SimpleSdkLaunchPlanRegistry {
+  public ContainerLaunchPlanRegistry() {
+    registerLaunchPlan(SdkLaunchPlan.of(new ContainerWorkflow()).withName("ContainerWorkflow"));
+  }
+}

--- a/flytekit-examples/src/main/java/org/flyte/examples/ContainerWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/ContainerWorkflow.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.examples;
+
+import com.google.auto.service.AutoService;
+import org.flyte.flytekit.SdkWorkflow;
+import org.flyte.flytekit.SdkWorkflowBuilder;
+
+/** Example workflow that takes a name and outputs a welcome message. */
+@AutoService(SdkWorkflow.class)
+public class ContainerWorkflow extends SdkWorkflow {
+
+  @Override
+  public void expand(SdkWorkflowBuilder builder) {
+    builder.apply("hello-container-task", new HelloContainerTask());
+  }
+}

--- a/flytekit-examples/src/main/java/org/flyte/examples/HelloContainerTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/HelloContainerTask.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.examples;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+
+import com.google.auto.service.AutoService;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.flyte.flytekit.SdkContainerTask;
+import org.flyte.flytekit.SdkTypes;
+
+/** Hello container in Flyte. */
+@AutoService(SdkContainerTask.class)
+public class HelloContainerTask extends SdkContainerTask<Void, Void> {
+
+  public HelloContainerTask() {
+    super(SdkTypes.nulls(), SdkTypes.nulls());
+  }
+
+  @Override
+  public String getImage() {
+    return "alpine";
+  }
+
+  @Override
+  public List<String> getArgs() {
+    return Arrays.asList("-c", "echo Hello $NAME");
+  }
+
+  @Override
+  public List<String> getCommand() {
+    return singletonList("sh");
+  }
+
+  @Override
+  public Map<String, String> getEnv() {
+    return singletonMap("NAME", "Joe");
+  }
+}

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkContainerTask.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkContainerTask.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.flyte.api.v1.PartialTaskIdentifier;
+
+/** Building block for tasks that execute arbitrary containers. */
+public abstract class SdkContainerTask<InputT, OutputT> extends SdkTransform
+    implements Serializable {
+
+  private static final long serialVersionUID = 42L;
+
+  private final transient SdkType<InputT> inputType;
+  private final transient SdkType<OutputT> outputType;
+
+  @SuppressWarnings("PublicConstructorForAbstractClass")
+  public SdkContainerTask(SdkType<InputT> inputType, SdkType<OutputT> outputType) {
+    this.inputType = inputType;
+    this.outputType = outputType;
+  }
+
+  // constructor used for serialization
+  //
+  // we want to make class serializable because big data processing frameworks
+  // tend to capture outer classes into closures, and serialize them
+  private SdkContainerTask() {
+    this.inputType = null;
+    this.outputType = null;
+  }
+
+  public String getType() {
+    return "raw-container";
+  }
+
+  /** Specifies task name. */
+  public String getName() {
+    return getClass().getName();
+  }
+
+  /** Specifies task input type. */
+  public SdkType<InputT> getInputType() {
+    return inputType;
+  }
+
+  /** Specifies task output type. */
+  public SdkType<OutputT> getOutputType() {
+    return outputType;
+  }
+
+  /** Specifies custom container parameters. */
+  public SdkStruct getCustom() {
+    return SdkStruct.empty();
+  }
+
+  /** Specifies container resource requests. */
+  public SdkResources getResources() {
+    return SdkResources.empty();
+  }
+
+  /**
+   * Number of retries. Retries will be consumed when the task fails with a recoverable error. The
+   * number of retries must be less than or equals to 10.
+   *
+   * @return number of retries
+   */
+  public int getRetries() {
+    return 0;
+  }
+
+  @Override
+  public SdkNode apply(
+      SdkWorkflowBuilder builder,
+      String nodeId,
+      List<String> upstreamNodeIds,
+      @Nullable SdkNodeMetadata metadata,
+      Map<String, SdkBindingData> inputs) {
+    PartialTaskIdentifier taskId = PartialTaskIdentifier.builder().name(getName()).build();
+    List<CompilerError> errors =
+        Compiler.validateApply(nodeId, inputs, getInputType().getVariableMap());
+
+    if (!errors.isEmpty()) {
+      throw new CompilerException(errors);
+    }
+
+    return new SdkTaskNode(
+        builder, nodeId, taskId, upstreamNodeIds, metadata, inputs, outputType.getVariableMap());
+  }
+
+  /** Specifies container image. */
+  public abstract String getImage();
+
+  /** Specifies command line arguments for container command. */
+  public List<String> getArgs() {
+    return emptyList();
+  }
+
+  /** Specifies container command. Example: {@code List.of("java", "-Xmx1G")}. */
+  public List<String> getCommand() {
+    return emptyList();
+  }
+
+  /** Specifies container environment variables. */
+  public Map<String, String> getEnv() {
+    return emptyMap();
+  }
+}

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkContainerTaskRegistrar.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkContainerTaskRegistrar.java
@@ -18,33 +18,36 @@ package org.flyte.flytekit;
 
 import com.google.auto.service.AutoService;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.flyte.api.v1.Literal;
+import java.util.stream.Collectors;
+import org.flyte.api.v1.ContainerTask;
+import org.flyte.api.v1.ContainerTaskRegistrar;
+import org.flyte.api.v1.KeyValuePair;
 import org.flyte.api.v1.Resources;
 import org.flyte.api.v1.RetryStrategy;
 import org.flyte.api.v1.RunnableTask;
-import org.flyte.api.v1.RunnableTaskRegistrar;
 import org.flyte.api.v1.Struct;
 import org.flyte.api.v1.TaskIdentifier;
 import org.flyte.api.v1.TypedInterface;
 
 /** A registrar that creates {@link RunnableTask} instances. */
-@AutoService(RunnableTaskRegistrar.class)
-public class SdkRunnableTaskRegistrar extends RunnableTaskRegistrar {
-  private static final Logger LOG = Logger.getLogger(SdkRunnableTaskRegistrar.class.getName());
+@AutoService(ContainerTaskRegistrar.class)
+public class SdkContainerTaskRegistrar extends ContainerTaskRegistrar {
+  private static final Logger LOG = Logger.getLogger(SdkContainerTaskRegistrar.class.getName());
 
   static {
     // enable all levels for the actual handler to pick up
     LOG.setLevel(Level.ALL);
   }
 
-  private static class RunnableTaskImpl<InputT, OutputT> implements RunnableTask {
-    private final SdkRunnableTask<InputT, OutputT> sdkTask;
+  private static class ContainerTaskImpl<InputT, OutputT> implements ContainerTask {
+    private final SdkContainerTask<InputT, OutputT> sdkTask;
 
-    private RunnableTaskImpl(SdkRunnableTask<InputT, OutputT> sdkTask) {
+    private ContainerTaskImpl(SdkContainerTask<InputT, OutputT> sdkTask) {
       this.sdkTask = sdkTask;
     }
 
@@ -67,14 +70,6 @@ public class SdkRunnableTaskRegistrar extends RunnableTaskRegistrar {
     }
 
     @Override
-    public Map<String, Literal> run(Map<String, Literal> inputs) {
-      InputT value = sdkTask.getInputType().fromLiteralMap(inputs);
-      OutputT output = sdkTask.run(value);
-
-      return sdkTask.getOutputType().toLiteralMap(output);
-    }
-
-    @Override
     public RetryStrategy getRetries() {
       return RetryStrategy.builder().retries(sdkTask.getRetries()).build();
     }
@@ -85,6 +80,28 @@ public class SdkRunnableTaskRegistrar extends RunnableTaskRegistrar {
     }
 
     @Override
+    public String getImage() {
+      return sdkTask.getImage();
+    }
+
+    @Override
+    public List<String> getArgs() {
+      return sdkTask.getArgs();
+    }
+
+    @Override
+    public List<String> getCommand() {
+      return sdkTask.getCommand();
+    }
+
+    @Override
+    public List<KeyValuePair> getEnv() {
+      return sdkTask.getEnv().entrySet().stream()
+          .map(entry -> KeyValuePair.of(entry.getKey(), entry.getValue()))
+          .collect(Collectors.toList());
+    }
+
+    @Override
     public Resources getResources() {
       return sdkTask.getResources().toResources();
     }
@@ -92,15 +109,16 @@ public class SdkRunnableTaskRegistrar extends RunnableTaskRegistrar {
 
   @Override
   @SuppressWarnings("rawtypes")
-  public Map<TaskIdentifier, RunnableTask> load(Map<String, String> env, ClassLoader classLoader) {
-    ServiceLoader<SdkRunnableTask> loader = ServiceLoader.load(SdkRunnableTask.class, classLoader);
+  public Map<TaskIdentifier, ContainerTask> load(Map<String, String> env, ClassLoader classLoader) {
+    ServiceLoader<SdkContainerTask> loader =
+        ServiceLoader.load(SdkContainerTask.class, classLoader);
 
-    LOG.fine("Discovering SdkRunnableTask");
+    LOG.fine("Discovering SdkContainerTask");
 
-    Map<TaskIdentifier, RunnableTask> tasks = new HashMap<>();
+    Map<TaskIdentifier, ContainerTask> tasks = new HashMap<>();
     SdkConfig sdkConfig = SdkConfig.load(env);
 
-    for (SdkRunnableTask<?, ?> sdkTask : loader) {
+    for (SdkContainerTask<?, ?> sdkTask : loader) {
       String name = sdkTask.getName();
       TaskIdentifier taskId =
           TaskIdentifier.builder()
@@ -111,8 +129,8 @@ public class SdkRunnableTaskRegistrar extends RunnableTaskRegistrar {
               .build();
       LOG.fine(String.format("Discovered [%s]", name));
 
-      RunnableTask task = new RunnableTaskImpl<>(sdkTask);
-      RunnableTask previous = tasks.put(taskId, task);
+      ContainerTask task = new ContainerTaskImpl<>(sdkTask);
+      ContainerTask previous = tasks.put(taskId, task);
 
       if (previous != null) {
         throw new IllegalArgumentException(

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkContainerTaskRegistrar.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkContainerTaskRegistrar.java
@@ -103,7 +103,7 @@ public class SdkContainerTaskRegistrar extends ContainerTaskRegistrar {
 
     @Override
     public Resources getResources() {
-      return sdkTask.getResources().toResources();
+      return sdkTask.getResources().toIdl();
     }
   }
 

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkResources.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkResources.java
@@ -75,7 +75,7 @@ public abstract class SdkResources {
     return EMPTY;
   }
 
-  public Resources toResources() {
+  public Resources toIdl() {
     Resources.Builder builder = Resources.builder();
 
     if (limits() != null) {

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkResources.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkResources.java
@@ -20,8 +20,10 @@ import static java.util.Collections.unmodifiableMap;
 
 import com.google.auto.value.AutoValue;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.flyte.api.v1.Resources;
 
 @AutoValue
 public abstract class SdkResources {
@@ -34,7 +36,25 @@ public abstract class SdkResources {
     STORAGE,
     // For Kubernetes-based deployments, pods use ephemeral local storage for scratch space,
     // caching, and for logs.
-    EPHEMERAL_STORAGE
+    EPHEMERAL_STORAGE;
+
+    public Resources.ResourceName toResourceName() {
+      switch (this) {
+        case UNKNOWN:
+          return Resources.ResourceName.UNKNOWN;
+        case CPU:
+          return Resources.ResourceName.CPU;
+        case GPU:
+          return Resources.ResourceName.GPU;
+        case MEMORY:
+          return Resources.ResourceName.MEMORY;
+        case STORAGE:
+          return Resources.ResourceName.STORAGE;
+        case EPHEMERAL_STORAGE:
+          return Resources.ResourceName.EPHEMERAL_STORAGE;
+      }
+      throw new AssertionError("Unexpected SdkResources.ResourceName: " + this);
+    }
   }
 
   private static final SdkResources EMPTY = builder().build();
@@ -53,6 +73,27 @@ public abstract class SdkResources {
 
   public static SdkResources empty() {
     return EMPTY;
+  }
+
+  public Resources toResources() {
+    Resources.Builder builder = Resources.builder();
+
+    if (limits() != null) {
+      builder.limits(toResourceMap(limits()));
+    }
+    if (requests() != null) {
+      builder.requests(toResourceMap(requests()));
+    }
+
+    return builder.build();
+  }
+
+  private Map<Resources.ResourceName, String> toResourceMap(
+      Map<SdkResources.ResourceName, String> sdkResources) {
+    Map<Resources.ResourceName, String> result = new HashMap<>();
+    sdkResources.forEach(
+        (sdkResourceName, value) -> result.put(sdkResourceName.toResourceName(), value));
+    return result;
   }
 
   @AutoValue.Builder

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkRunnableTaskRegistrar.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkRunnableTaskRegistrar.java
@@ -86,7 +86,7 @@ public class SdkRunnableTaskRegistrar extends RunnableTaskRegistrar {
 
     @Override
     public Resources getResources() {
-      return sdkTask.getResources().toResources();
+      return sdkTask.getResources().toIdl();
     }
   }
 

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkContainerTaskRegistrarTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkContainerTaskRegistrarTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit;
+
+import static java.util.Collections.singletonMap;
+import static org.flyte.flytekit.SdkConfig.DOMAIN_ENV_VAR;
+import static org.flyte.flytekit.SdkConfig.PROJECT_ENV_VAR;
+import static org.flyte.flytekit.SdkConfig.VERSION_ENV_VAR;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.google.auto.service.AutoService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.flyte.api.v1.ContainerTask;
+import org.flyte.api.v1.KeyValuePair;
+import org.flyte.api.v1.Resources;
+import org.flyte.api.v1.TaskIdentifier;
+import org.flyte.api.v1.TypedInterface;
+import org.junit.jupiter.api.Test;
+
+public class SdkContainerTaskRegistrarTest {
+  private static final Map<String, String> ENV;
+
+  static {
+    HashMap<String, String> env = new HashMap<>();
+    env.put(PROJECT_ENV_VAR, "project");
+    env.put(DOMAIN_ENV_VAR, "domain");
+    env.put(VERSION_ENV_VAR, "version");
+    ENV = Collections.unmodifiableMap(env);
+  }
+
+  private static final String TEST_TASK_NAME =
+      "org.flyte.flytekit.SdkContainerTaskRegistrarTest$TestTask";
+  private static final String OTHER_TEST_TASK_NAME =
+      "org.flyte.flytekit.SdkContainerTaskRegistrarTest$OtherTestTask";
+  private final SdkContainerTaskRegistrar registrar = new SdkContainerTaskRegistrar();
+
+  @Test
+  void shouldLoadMultipleTasksFromDiscoveredRegistries() {
+    // given
+    TaskIdentifier expectedTestTaskId = taskIdentifier(TEST_TASK_NAME);
+    TaskIdentifier expectedOtherTestTaskId = taskIdentifier(OTHER_TEST_TASK_NAME);
+
+    // when
+    Map<TaskIdentifier, ContainerTask> tasks = registrar.load(ENV);
+
+    // then
+    assertAll(
+        () -> assertThat(tasks, hasKey(is(expectedTestTaskId))),
+        () -> assertThat(tasks, hasKey(is(expectedOtherTestTaskId))));
+  }
+
+  @Test
+  void shouldLoadTaskParameters() {
+    // given
+    TaskIdentifier expectedTestTaskId = taskIdentifier(TEST_TASK_NAME);
+
+    // when
+    Map<TaskIdentifier, ContainerTask> tasks = registrar.load(ENV);
+
+    // then
+    ContainerTask task = tasks.get(expectedTestTaskId);
+
+    assertThat(task.getName(), equalTo(TEST_TASK_NAME));
+    assertThat(task.getType(), equalTo("raw-container"));
+    assertThat(
+        task.getInterface(),
+        equalTo(
+            TypedInterface.builder()
+                .inputs(SdkTypes.nulls().getVariableMap())
+                .outputs(SdkTypes.nulls().getVariableMap())
+                .build()));
+    assertThat(
+        task.getResources(),
+        equalTo(
+            Resources.builder()
+                .requests(resources("0.5", "2Gi"))
+                .limits(resources("2", "5Gi"))
+                .build()));
+    assertThat(task.getImage(), equalTo("image"));
+    assertThat(task.getArgs(), contains("-c", "echo hello"));
+    assertThat(task.getCommand(), contains("bash"));
+    assertThat(task.getEnv(), contains(KeyValuePair.of("KEY", "VALUE")));
+  }
+
+  @AutoService(SdkContainerTask.class)
+  public static class TestTask extends SdkContainerTask<Void, Void> {
+
+    private static final long serialVersionUID = 2751205856616541247L;
+
+    public TestTask() {
+      super(SdkTypes.nulls(), SdkTypes.nulls());
+    }
+
+    @Override
+    public SdkResources getResources() {
+      return SdkResources.builder()
+          .requests(sdkResources("0.5", "2Gi"))
+          .limits(sdkResources("2", "5Gi"))
+          .build();
+    }
+
+    @Override
+    public String getImage() {
+      return "image";
+    }
+
+    @Override
+    public List<String> getArgs() {
+      return Arrays.asList("-c", "echo hello");
+    }
+
+    @Override
+    public List<String> getCommand() {
+      return Arrays.asList("bash");
+    }
+
+    @Override
+    public Map<String, String> getEnv() {
+      return singletonMap("KEY", "VALUE");
+    }
+  }
+
+  @AutoService(SdkContainerTask.class)
+  public static class OtherTestTask extends SdkContainerTask<Void, Void> {
+
+    private static final long serialVersionUID = -7757282344498000982L;
+
+    public OtherTestTask() {
+      super(SdkTypes.nulls(), SdkTypes.nulls());
+    }
+
+    @Override
+    public String getImage() {
+      return "other-image";
+    }
+  }
+
+  private static TaskIdentifier taskIdentifier(String taskName) {
+    return TaskIdentifier.builder()
+        .project("project")
+        .domain("domain")
+        .name(taskName)
+        .version("version")
+        .build();
+  }
+
+  private static Map<Resources.ResourceName, String> resources(String cpu, String memory) {
+    Map<Resources.ResourceName, String> limits = new HashMap<>();
+    limits.put(Resources.ResourceName.CPU, cpu);
+    limits.put(Resources.ResourceName.MEMORY, memory);
+    return limits;
+  }
+
+  private static Map<SdkResources.ResourceName, String> sdkResources(String cpu, String memory) {
+    Map<SdkResources.ResourceName, String> limits = new HashMap<>();
+    limits.put(SdkResources.ResourceName.CPU, cpu);
+    limits.put(SdkResources.ResourceName.MEMORY, memory);
+    return limits;
+  }
+}

--- a/jflyte/src/main/java/org/flyte/jflyte/ProjectClosure.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/ProjectClosure.java
@@ -49,6 +49,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.flyte.api.v1.Container;
+import org.flyte.api.v1.ContainerTask;
+import org.flyte.api.v1.ContainerTaskRegistrar;
 import org.flyte.api.v1.DynamicWorkflowTask;
 import org.flyte.api.v1.DynamicWorkflowTaskRegistrar;
 import org.flyte.api.v1.IfBlock;
@@ -203,6 +205,10 @@ abstract class ProjectClosure {
         ClassLoaders.withClassLoader(
             packageClassLoader, () -> Registrars.loadAll(DynamicWorkflowTaskRegistrar.class, env));
 
+    Map<TaskIdentifier, ContainerTask> containerTasks =
+        ClassLoaders.withClassLoader(
+            packageClassLoader, () -> Registrars.loadAll(ContainerTaskRegistrar.class, env));
+
     Map<WorkflowIdentifier, WorkflowTemplate> workflows =
         ClassLoaders.withClassLoader(
             packageClassLoader, () -> Registrars.loadAll(WorkflowTemplateRegistrar.class, env));
@@ -211,7 +217,14 @@ abstract class ProjectClosure {
         ClassLoaders.withClassLoader(
             packageClassLoader, () -> Registrars.loadAll(LaunchPlanRegistrar.class, env));
 
-    return load(config, rewrite, runnableTasks, dynamicWorkflowTasks, workflows, launchPlans);
+    return load(
+        config,
+        rewrite,
+        runnableTasks,
+        dynamicWorkflowTasks,
+        containerTasks,
+        workflows,
+        launchPlans);
   }
 
   static ProjectClosure load(
@@ -219,10 +232,11 @@ abstract class ProjectClosure {
       IdentifierRewrite rewrite,
       Map<TaskIdentifier, RunnableTask> runnableTasks,
       Map<TaskIdentifier, DynamicWorkflowTask> dynamicWorkflowTasks,
+      Map<TaskIdentifier, ContainerTask> containerTasks,
       Map<WorkflowIdentifier, WorkflowTemplate> workflowTemplates,
       Map<LaunchPlanIdentifier, LaunchPlan> launchPlans) {
     Map<TaskIdentifier, TaskTemplate> taskTemplates =
-        createTaskTemplates(config, runnableTasks, dynamicWorkflowTasks);
+        createTaskTemplates(config, runnableTasks, dynamicWorkflowTasks, containerTasks);
 
     // 2. rewrite workflows and launch plans
     Map<WorkflowIdentifier, WorkflowTemplate> rewrittenWorkflowTemplates =
@@ -379,7 +393,8 @@ abstract class ProjectClosure {
   static Map<TaskIdentifier, TaskTemplate> createTaskTemplates(
       ExecutionConfig config,
       Map<TaskIdentifier, RunnableTask> runnableTasks,
-      Map<TaskIdentifier, DynamicWorkflowTask> dynamicWorkflowTasks) {
+      Map<TaskIdentifier, DynamicWorkflowTask> dynamicWorkflowTasks,
+      Map<TaskIdentifier, ContainerTask> containerTasks) {
     Map<TaskIdentifier, TaskTemplate> taskTemplates = new HashMap<>();
 
     runnableTasks.forEach(
@@ -392,6 +407,13 @@ abstract class ProjectClosure {
     dynamicWorkflowTasks.forEach(
         (id, task) -> {
           TaskTemplate taskTemplate = createTaskTemplateForDynamicWorkflow(task, config.image());
+
+          taskTemplates.put(id, taskTemplate);
+        });
+
+    containerTasks.forEach(
+        (id, task) -> {
+          TaskTemplate taskTemplate = createTaskTemplateForContainerTask(task);
 
           taskTemplates.put(id, taskTemplate);
         });
@@ -419,6 +441,27 @@ abstract class ProjectClosure {
                     "{{.taskTemplatePath}}"))
             .image(image)
             .env(javaToolOptionsEnv(resources).map(ImmutableList::of).orElse(ImmutableList.of()))
+            .resources(resources)
+            .build();
+
+    return TaskTemplate.builder()
+        .container(container)
+        .interface_(task.getInterface())
+        .retries(task.getRetries())
+        .type(task.getType())
+        .custom(task.getCustom())
+        .build();
+  }
+
+  @VisibleForTesting
+  static TaskTemplate createTaskTemplateForContainerTask(ContainerTask task) {
+    Resources resources = task.getResources();
+    Container container =
+        Container.builder()
+            .command(task.getCommand())
+            .args(task.getArgs())
+            .image(task.getImage())
+            .env(task.getEnv())
             .resources(resources)
             .build();
 

--- a/jflyte/src/main/java/org/flyte/jflyte/ProjectClosure.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/ProjectClosure.java
@@ -159,7 +159,7 @@ abstract class ProjectClosure {
     ProjectClosure closure = ProjectClosure.load(config, rewrite, packageClassLoader);
 
     List<Artifact> artifacts;
-    if (!closure.taskSpecs().isEmpty()) {
+    if (isStagingRequired(closure)) {
       artifacts = stagePackageFiles(stagerSupplier.get(), packageDir);
     } else {
       artifacts = emptyList();
@@ -170,6 +170,13 @@ abstract class ProjectClosure {
     JFlyteCustom custom = JFlyteCustom.builder().artifacts(artifacts).build();
 
     return closure.applyCustom(custom);
+  }
+
+  private static boolean isStagingRequired(ProjectClosure closure) {
+    return closure.taskSpecs().values().stream()
+        .map(TaskSpec::taskTemplate)
+        .map(TaskTemplate::type)
+        .anyMatch(type -> !type.equals("raw-container"));
   }
 
   private static List<Artifact> stagePackageFiles(ArtifactStager stager, String packageDir) {


### PR DESCRIPTION
Adds support for ContainerTask: https://docs.flyte.org/projects/flytekit/en/latest/generated/flytekit.ContainerTask.html

Container tasks will allow to execute arbitrary container as Flyte task.

# TL;DR
Adds `ContainerTask` allowing to execute arbitrary container as a Flyte task. Such functionality already exists in Python SDK: https://docs.flyte.org/projects/flytekit/en/latest/generated/flytekit.ContainerTask.html 

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
[ContainerTask](https://docs.flyte.org/projects/flytekit/en/latest/generated/flytekit.ContainerTask.html) functionality has been ported with minimal changes to the API. Container tasks will have its own registar therefore minimum changes were made to existing code for runnable tasks.

An example of a container task added here: https://github.com/evdokim/flytekit-java/blob/container-task/flytekit-examples/src/main/java/org/flyte/examples/HelloContainerTask.java

## Tracking Issue
No issues has been created

## Follow-up issue
No follow up issues
