### PR TITLE
Bump libraries reported by snyk

### DIFF
--- a/flyteidl-protos/pom.xml
+++ b/flyteidl-protos/pom.xml
@@ -102,11 +102,11 @@
               <artifactId>auto-service</artifactId>
               <version>${auto-service.version}</version>
             </path>
-            <path>
+            <!--<path>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
               <version>${error_prone.version}</version>
-            </path>
+            </path>-->
           </annotationProcessorPaths>
         </configuration>
       </plugin>

--- a/flyteidl-protos/pom.xml
+++ b/flyteidl-protos/pom.xml
@@ -102,11 +102,11 @@
               <artifactId>auto-service</artifactId>
               <version>${auto-service.version}</version>
             </path>
-            <!--<path>
+            <path>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
               <version>${error_prone.version}</version>
-            </path>-->
+            </path>
           </annotationProcessorPaths>
         </configuration>
       </plugin>

--- a/flytekit-scala_2.13/pom.xml
+++ b/flytekit-scala_2.13/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <scala.baseVersion>2.13</scala.baseVersion>
-    <scala.version>2.13.6</scala.version>
+    <scala.version>2.13.8</scala.version>
 
     <magnolia.version>1.0.0-M4</magnolia.version>
 

--- a/jflyte/src/test/java/org/flyte/jflyte/ExecuteLocalArgsParserTest.java
+++ b/jflyte/src/test/java/org/flyte/jflyte/ExecuteLocalArgsParserTest.java
@@ -228,7 +228,7 @@ public class ExecuteLocalArgsParserTest {
             CommandLine.ParameterException.class,
             () -> parseInputs(ImmutableMap.of("arg", createVar(SimpleType.STRING)), new String[0]));
 
-    assertEquals("Missing required option '--arg'", exception.getMessage());
+    assertEquals("Missing required option: '--arg'", exception.getMessage());
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -777,11 +777,11 @@
       </build>
     </profile>
 
-    <!--<profile>
+    <profile>
       <id>errorprone</id>
       <activation>
         <property>
-          <name>!errorprone.skip</name>
+          <name>errorprone.enable</name>
         </property>
       </activation>
       <build>
@@ -800,7 +800,7 @@
           </plugins>
         </pluginManagement>
       </build>
-    </profile>-->
+    </profile>
 
     <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -802,29 +802,6 @@
       </build>
     </profile>
 
-    <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
-    <profile>
-      <id>jdk8</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <fork>true</fork>
-                <!--<compilerArgs combine.children="append">
-                  <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${error_prone.javac.version}/javac-${error_prone.javac.version}.jar</arg>
-                </compilerArgs>-->
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
     <profile>
       <id>jdk9+</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -336,11 +336,11 @@
                 <artifactId>auto-service</artifactId>
                 <version>${auto-service.version}</version>
               </path>
-              <!--<path>
+              <path>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
                 <version>${error_prone.version}</version>
-              </path>-->
+              </path>
             </annotationProcessorPaths>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -84,21 +84,19 @@
   </distributionManagement>
 
   <properties>
-    <auto-service.version>1.0-rc6</auto-service.version>
+    <auto-service.version>1.0.1</auto-service.version>
     <auto-value.version>1.8.2</auto-value.version>
     <common-proto.version>2.3.2</common-proto.version>
     <grpc.version>1.40.1</grpc.version>
     <!-- must be aligned with netty version -->
     <!-- see: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-    <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
-    <picocli.version>4.2.0</picocli.version>
+    <netty.tcnative.version>2.0.52.Final</netty.tcnative.version>
+    <picocli.version>4.6.3</picocli.version>
     <protobuf.version>3.18.2</protobuf.version>
     <sl4j.version>1.7.32</sl4j.version>
     <spotless.version>2.21.0</spotless.version>
     <spotbugs.excludeFilterFile>spotbugs-exclude.xml</spotbugs.excludeFilterFile>
-    <error_prone.version>2.10.0</error_prone.version>
-    <!-- Using the error-prone-javac is required when running on JDK 8 -->
-    <error_prone.javac.version>9+181-r4173-1</error_prone.javac.version>
+    <error_prone.version>2.13.1</error_prone.version>
     <junit.version>5.6.2</junit.version>
 
     <!-- has to be one liner, or errorprone doesn't work -->
@@ -180,6 +178,11 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>31.0.1-jre</version>
+      </dependency>
       <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-bom</artifactId>
@@ -333,11 +336,11 @@
                 <artifactId>auto-service</artifactId>
                 <version>${auto-service.version}</version>
               </path>
-              <path>
+              <!--<path>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
                 <version>${error_prone.version}</version>
-              </path>
+              </path>-->
             </annotationProcessorPaths>
           </configuration>
         </plugin>
@@ -774,7 +777,7 @@
       </build>
     </profile>
 
-    <profile>
+    <!--<profile>
       <id>errorprone</id>
       <activation>
         <property>
@@ -797,7 +800,7 @@
           </plugins>
         </pluginManagement>
       </build>
-    </profile>
+    </profile>-->
 
     <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
     <profile>
@@ -813,9 +816,9 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <configuration>
                 <fork>true</fork>
-                <compilerArgs combine.children="append">
+                <!--<compilerArgs combine.children="append">
                   <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${error_prone.javac.version}/javac-${error_prone.javac.version}.jar</arg>
-                </compilerArgs>
+                </compilerArgs>-->
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,9 @@
     <!-- has to be one liner, or errorprone doesn't work -->
     <error-prone-base-config><![CDATA[-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/generated-(test-)?sources/.*]]></error-prone-base-config>
     <error-prone-additional-args>-Xep:AutoValueImmutableFields:OFF -Xep:Var:ERROR</error-prone-additional-args>
+
+    <!-- Keep generated .class files java 8 compatible -->
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencyManagement>
@@ -801,19 +804,5 @@
         </pluginManagement>
       </build>
     </profile>
-
-    <profile>
-      <id>jdk9+</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <properties>
-        <!-- Javac introduced the "release" option only in Java 9+.  It
-          properly sets up source, target and boot classpath for the best
-          compatibility with different versions of Java. -->
-        <maven.compiler.release>8</maven.compiler.release>
-      </properties>
-    </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
# TL;DR
Snyk bot reports some outdated libraries versions that requires bumping the versions

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Snyk bot reports some outdated libraries versions that requires bumping the versions.
One of the bumped libraries is error prone but that created a clash with guava version, so for now it is not enabled by default.
Also removed the jdk 8 profile, time to let it go

## Follow-up issue
We need to enable error prone by default