### PR TITLE
[patch] Tiny fixes: m1 + jflyte error 

### DIFF
--- a/flyteidl-protos/pom.xml
+++ b/flyteidl-protos/pom.xml
@@ -50,7 +50,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.6.1</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:3.11.0:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:3.21.1:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
           <checkStaleness>true</checkStaleness>

--- a/scripts/jflyte
+++ b/scripts/jflyte
@@ -3,8 +3,7 @@
 set -uea -o pipefail
 
 DIR="$(dirname $0)/../"
-CUSTOM_FLYTE_INTERNAL_IMAGE="$(cat $DIR/jflyte-build/target/docker/image-name)"
-
+CUSTOM_FLYTE_INTERNAL_IMAGE=$(jq -r '.image +":" + .tags[0]' jflyte/target/jib-image.json)
 if [ -e "$DIR/.env.local" ]; then
     source "$DIR/.env.local"
 fi


### PR DESCRIPTION
# TL;DR
1. Upgrading protoc to support arm architectures (m1 macs). 
2. Fixing broken `jflyte` script.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
- Trying to do `mvn package` on an m1 mac results in an error while fetching `com.google.protobuf:protoc`. 
   - Upgraded version to avoid this error
- `scripts/jflyte` is broken after the introduction of `jib`.
   -  This PR uses jib's outputs to figure out what is the built docker image
   -  ⚠️ I tried to use `jib-image.digest` however this is not ideal because the digest won't exist until the docker image is pushed to a docker repository ([why my docker image does not have a digest](https://stackoverflow.com/questions/39811230/why-doesnt-my-newly-created-docker-have-a-digest))
   - Decided to go for the docker tag. I had to parse jib's output json file, which means I had to bring `jq`
   - 🙏  any suggestions?
   
## Tracking Issue
_NA_

## Follow-up issue
_NA_
