### PR TITLE
[doc] Update README to add Java 11 and jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To learn more about Flyte refer to:
 
 ## Build from source
 
-It requires **Java 1.8 and Docker**
+It requires **Java 11 and Docker**
 
 ```bash
 mvn clean verify
@@ -69,6 +69,8 @@ $ scripts/jflyte register workflows \
   -v=$(git describe --always) \
   -cp=flytekit-examples/target/lib
 ```
+
+**Note**: `scripts/jflyte` requires `jq` to run, in adition to `docker`
 
 ## Usage
 


### PR DESCRIPTION
# TL;DR
Update README to update Java version to 11 and mention that `jq` is needed to run the `jflyte` script

## Type
 - [x] Documentation
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [X] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We need to keep the Readme relevant
* Java 11 was introduced a while ago, but we failed to update the readme
* `jq` as introduced in https://github.com/flyteorg/flytekit-java/pull/114

## Follow-up issue
_NA_
