### PR TITLE
Add support for mocking sub-workflows

### DIFF
--- a/flytekit-examples/src/test/java/org/flyte/examples/WorkflowTest.java
+++ b/flytekit-examples/src/test/java/org/flyte/examples/WorkflowTest.java
@@ -18,6 +18,10 @@ package org.flyte.examples;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.HashMap;
+import java.util.Map;
+import org.flyte.api.v1.Literal;
+import org.flyte.flytekit.testing.Literals;
 import org.flyte.flytekit.testing.SdkTestingExecutor;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +41,7 @@ public class WorkflowTest {
   }
 
   @Test
-  public void testMockSubWorkflow() {
+  public void testMockTasks() {
     SdkTestingExecutor.Result result =
         SdkTestingExecutor.of(new UberWorkflow())
             .withFixedInput("a", 1)
@@ -48,6 +52,35 @@ public class WorkflowTest {
                 new SumTask(), SumTask.SumInput.create(1L, 2L), SumTask.SumOutput.create(0L))
             .withTaskOutput(
                 new SumTask(), SumTask.SumInput.create(0L, 3L), SumTask.SumOutput.create(0L))
+            .withTaskOutput(
+                new SumTask(), SumTask.SumInput.create(0L, 4L), SumTask.SumOutput.create(42L))
+            .execute();
+
+    assertEquals(42L, result.getIntegerOutput("total"));
+  }
+
+  @Test
+  public void testMockSubWorkflow() {
+    Map<String, Literal> sub1Inputs = new HashMap<>();
+    sub1Inputs.put("left", Literals.ofInteger(1));
+    sub1Inputs.put("right", Literals.ofInteger(2));
+    Map<String, Literal> sub1Outputs = new HashMap<>();
+    sub1Outputs.put("result", Literals.ofInteger(0));
+
+    Map<String, Literal> sub2Inputs = new HashMap<>();
+    sub2Inputs.put("left", Literals.ofInteger(0));
+    sub2Inputs.put("right", Literals.ofInteger(3));
+    Map<String, Literal> sub2Outputs = new HashMap<>();
+    sub2Outputs.put("result", Literals.ofInteger(0));
+
+    SdkTestingExecutor.Result result =
+        SdkTestingExecutor.of(new UberWorkflow())
+            .withFixedInput("a", 1)
+            .withFixedInput("b", 2)
+            .withFixedInput("c", 3)
+            .withFixedInput("d", 4)
+            .withWorkflowOutput(new SubWorkflow(), sub1Inputs, sub1Outputs)
+            .withWorkflowOutput(new SubWorkflow(), sub2Inputs, sub2Outputs)
             .withTaskOutput(
                 new SumTask(), SumTask.SumInput.create(0L, 4L), SumTask.SumOutput.create(42L))
             .execute();

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/DummyTask.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/DummyTask.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.testing;
+
+import java.util.Map;
+import org.flyte.api.v1.Literal;
+import org.flyte.flytekit.SdkRemoteTask;
+import org.flyte.flytekit.SdkType;
+
+public class DummyTask extends SdkRemoteTask<Map<String, Literal>, Map<String, Literal>> {
+
+  private final String name;
+
+  private final SdkType<Map<String, Literal>> inputs;
+
+  private final SdkType<Map<String, Literal>> outputs;
+
+  public DummyTask(
+      String name, SdkType<Map<String, Literal>> inputs, SdkType<Map<String, Literal>> outputs) {
+    this.name = name;
+    this.inputs = inputs;
+    this.outputs = outputs;
+  }
+
+  @Override
+  public String domain() {
+    return "";
+  }
+
+  @Override
+  public String project() {
+    return "";
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public SdkType<Map<String, Literal>> inputs() {
+    return this.inputs;
+  }
+
+  @Override
+  public SdkType<Map<String, Literal>> outputs() {
+    return this.outputs;
+  }
+}

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/Literals.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/Literals.java
@@ -30,29 +30,29 @@ import org.flyte.api.v1.Literal;
 import org.flyte.api.v1.Primitive;
 import org.flyte.api.v1.Scalar;
 
-class Literals {
+public class Literals {
 
-  static Literal ofInteger(long value) {
+  public static Literal ofInteger(long value) {
     return ofPrimitive(Primitive.ofIntegerValue(value));
   }
 
-  static Literal ofFloat(double value) {
+  public static Literal ofFloat(double value) {
     return ofPrimitive(Primitive.ofFloatValue(value));
   }
 
-  static Literal ofString(String value) {
+  public static Literal ofString(String value) {
     return ofPrimitive(Primitive.ofStringValue(value));
   }
 
-  static Literal ofBoolean(boolean value) {
+  public static Literal ofBoolean(boolean value) {
     return ofPrimitive(Primitive.ofBooleanValue(value));
   }
 
-  static Literal ofDatetime(Instant value) {
+  public static Literal ofDatetime(Instant value) {
     return ofPrimitive(Primitive.ofDatetime(value));
   }
 
-  static Literal ofDuration(Duration value) {
+  public static Literal ofDuration(Duration value) {
     return ofPrimitive(Primitive.ofDuration(value));
   }
 
@@ -60,7 +60,7 @@ class Literals {
     return Literal.ofScalar(Scalar.ofPrimitive(primitive));
   }
 
-  static BindingData toBindingData(Literal literal) {
+  public static BindingData toBindingData(Literal literal) {
     switch (literal.kind()) {
       case SCALAR:
         return BindingData.ofScalar(literal.scalar());

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingSdkType.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingSdkType.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.testing;
+
+import java.util.Map;
+import org.flyte.api.v1.Literal;
+import org.flyte.api.v1.Variable;
+import org.flyte.flytekit.SdkType;
+
+public class TestingSdkType extends SdkType<Map<String, Literal>> {
+
+  private final Map<String, Variable> variableMap;
+
+  private TestingSdkType(Map<String, Variable> variableMap) {
+    this.variableMap = variableMap;
+  }
+
+  @Override
+  public Map<String, Literal> toLiteralMap(Map<String, Literal> value) {
+    return value;
+  }
+
+  @Override
+  public Map<String, Literal> fromLiteralMap(Map<String, Literal> value) {
+    return value;
+  }
+
+  @Override
+  public Map<String, Variable> getVariableMap() {
+    return variableMap;
+  }
+
+  public static SdkType<Map<String, Literal>> of(Map<String, Variable> intf) {
+    return new TestingSdkType(intf);
+  }
+}

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingWorkflow.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingWorkflow.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.testing;
+
+import com.google.errorprone.annotations.Var;
+import java.util.Map;
+import org.flyte.api.v1.Literal;
+import org.flyte.api.v1.Variable;
+import org.flyte.flytekit.SdkNode;
+import org.flyte.flytekit.SdkTransform;
+import org.flyte.flytekit.SdkType;
+import org.flyte.flytekit.SdkWorkflow;
+import org.flyte.flytekit.SdkWorkflowBuilder;
+
+class TestingWorkflow extends SdkWorkflow {
+
+  private final SdkWorkflow workflow;
+  private final SdkType<Map<String, Literal>> inputs;
+  private final SdkType<Map<String, Literal>> outputs;
+
+  TestingWorkflow(
+      SdkWorkflow workflow,
+      SdkType<Map<String, Literal>> inputs,
+      SdkType<Map<String, Literal>> outputs) {
+    this.workflow = workflow;
+    this.inputs = inputs;
+    this.outputs = outputs;
+  }
+
+  @Override
+  public void expand(SdkWorkflowBuilder builder) {
+    @Var SdkTransform task = new DummyTask(workflow.getName(), inputs, outputs);
+    for (Map.Entry<String, Variable> i : inputs.getVariableMap().entrySet()) {
+      task =
+          task.withInput(i.getKey(), builder.inputOf(i.getKey(), i.getValue().literalType(), ""));
+    }
+
+    SdkNode node = builder.apply(workflow.getName(), task);
+
+    for (String o : outputs.getVariableMap().keySet()) {
+      builder.output(o, node.getOutput(o));
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Michel Davit <michel@davit.fr>

# TL;DR
Add support for mocking sub-workflows in tests

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Complete description

Give the ability to mock sub-workflow by giving a `Map<String, Literal>` for input and output, in a similar way for Task.
-> As workflows do not have input/output type, generic `Map<String, Literal>` are used
-> Literals constructor need to be made public
