### PR TITLE
Don't include module artifacts in jflyte

### DIFF
--- a/jflyte/pom.xml
+++ b/jflyte/pom.xml
@@ -58,10 +58,16 @@
     <dependency>
       <groupId>org.flyte</groupId>
       <artifactId>jflyte-aws</artifactId>
+      <!-- We want to have the dependency, so it is already built before building the docker image,
+           but we want to avoid the artifacts from the module to pollute jflyte -->
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.flyte</groupId>
       <artifactId>jflyte-google-cloud</artifactId>
+      <!-- We want to have the dependency, so it is already built before building the docker image,
+           but we want to avoid the artifacts from the module to pollute jflyte -->
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
# TL;DR
Revert the dependency of jflyte and it's modules

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
On we made a mistake to create a dependency from jflyte to its modules, meaning that we include the modules artifacts and its dependencies inside jflye, defeating the purpose of independent modules.

Notice that the inverse is correct, a module should depend on jflyte, as it would implement the interface `FileSystem` or `ArtifactStager` defined in jflyte.

Beside possible dependency conflicts of including modules artifact in jflyte, it also has the unexpected consequence of duplicating the artifacts in the docker image, as modules have their own independent modules.
