### PR TITLE
Bump libs versions reported by snyk

### DIFF
--- a/flytekit-java/src/main/java/org/flyte/flytekit/MoreCollectors.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/MoreCollectors.java
@@ -31,7 +31,7 @@ class MoreCollectors {
     return collectingAndThen(toList(), Collections::unmodifiableList);
   }
 
-  static <T, K, V> Collector<Map.Entry<K, V>, ?, Map<K, V>> toUnmodifiableMap() {
+  static <K, V> Collector<Map.Entry<K, V>, ?, Map<K, V>> toUnmodifiableMap() {
     return collectingAndThen(
         toMap(Map.Entry::getKey, Map.Entry::getValue), Collections::unmodifiableMap);
   }

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBranchNode.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBranchNode.java
@@ -22,6 +22,7 @@ import static java.util.Collections.unmodifiableList;
 import static org.flyte.flytekit.MoreCollectors.toUnmodifiableList;
 import static org.flyte.flytekit.MoreCollectors.toUnmodifiableMap;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Var;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -103,6 +104,7 @@ public class SdkBranchNode extends SdkNode {
       this.builder = builder;
     }
 
+    @CanIgnoreReturnValue
     Builder addCase(SdkConditionCase case_) {
       SdkNode sdkNode =
           case_.then().apply(builder, case_.name(), emptyList(), /*metadata=*/ null, emptyMap());
@@ -133,6 +135,7 @@ public class SdkBranchNode extends SdkNode {
       return this;
     }
 
+    @CanIgnoreReturnValue
     Builder addOtherwise(String name, SdkTransform otherwise) {
       if (elseNode != null) {
         throw new IllegalArgumentException("Duplicate otherwise clause");

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/ImmutableList.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/ImmutableList.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -94,6 +95,7 @@ public class ImmutableList {
 
     private final List<T> items = new ArrayList<>();
 
+    @CanIgnoreReturnValue
     public Builder<T> add(T item) {
       items.add(item);
       return this;

--- a/jflyte/src/main/java/org/flyte/jflyte/MoreCollectors.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/MoreCollectors.java
@@ -31,7 +31,7 @@ class MoreCollectors {
     return collectingAndThen(toList(), Collections::unmodifiableList);
   }
 
-  static <T, K, V> Collector<Map.Entry<K, V>, ?, Map<K, V>> toUnmodifiableMap() {
+  static <K, V> Collector<Map.Entry<K, V>, ?, Map<K, V>> toUnmodifiableMap() {
     return collectingAndThen(
         toMap(Map.Entry::getKey, Map.Entry::getValue), Collections::unmodifiableMap);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
   <properties>
     <auto-service.version>1.0.1</auto-service.version>
     <auto-value.version>1.9</auto-value.version>
-    <common-proto.version>2.9.1</common-proto.version>
+    <common-proto.version>2.9.2</common-proto.version>
     <grpc.version>1.46.0</grpc.version>
     <!-- must be aligned with netty version -->
     <!-- see: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
@@ -95,7 +95,7 @@
     <sl4j.version>1.7.36</sl4j.version>
     <spotless.version>2.21.0</spotless.version>
     <spotbugs.excludeFilterFile>spotbugs-exclude.xml</spotbugs.excludeFilterFile>
-    <error_prone.version>2.14.0</error_prone.version>
+    <error_prone.version>2.15.0</error_prone.version>
     <!-- Using the error-prone-javac is required when running on JDK 8 -->
     <error_prone.javac.version>9+181-r4173-1</error_prone.javac.version>
     <junit.version>5.6.2</junit.version>


### PR DESCRIPTION
# TL;DR
Bump libraries reported by snyk

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Bump libraries:
| lib | current version | new version |
|---|-----------------------|------------------|
| common-proto.version | 2.9.1 | 2.9.2 |
| error_prone.version | 2.14.0 | 2.15.0 |

These libraries bumps where reported in
* https://github.com/flyteorg/flytekit-java/pull/130
* https://github.com/flyteorg/flytekit-java/pull/128

Also I had to fix new complains brought by the newer version of error-prone

## Tracking Issue

## Follow-up issue
_NA_
