### PR TITLE
reuse test container locally

### DIFF
--- a/integration-tests/src/test/java/org/flyte/AdditionalIT.java
+++ b/integration-tests/src/test/java/org/flyte/AdditionalIT.java
@@ -21,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import flyteidl.core.Literals;
-import org.flyte.utils.FlyteSandboxClient;
 import org.flyte.utils.Literal;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/integration-tests/src/test/java/org/flyte/AdditionalIT.java
+++ b/integration-tests/src/test/java/org/flyte/AdditionalIT.java
@@ -16,6 +16,7 @@
  */
 package org.flyte;
 
+import static org.flyte.FlyteContainer.CLIENT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -28,8 +29,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 public class AdditionalIT {
-  private static final FlyteSandboxClient CLIENT = FlyteSandboxClient.create();
-
   @BeforeAll
   public static void beforeAll() {
     CLIENT.registerWorkflows("integration-tests/target/lib");

--- a/integration-tests/src/test/java/org/flyte/AdditionalIT.java
+++ b/integration-tests/src/test/java/org/flyte/AdditionalIT.java
@@ -23,10 +23,12 @@ import static org.hamcrest.Matchers.equalTo;
 import flyteidl.core.Literals;
 import org.flyte.utils.Literal;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AdditionalIT {
   @BeforeAll
   public static void beforeAll() {

--- a/integration-tests/src/test/java/org/flyte/FlyteContainer.java
+++ b/integration-tests/src/test/java/org/flyte/FlyteContainer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte;
+
+import org.flyte.utils.FlyteSandboxClient;
+
+public class FlyteContainer {
+  static final FlyteSandboxClient CLIENT = FlyteSandboxClient.create();
+}

--- a/integration-tests/src/test/java/org/flyte/JavaExamplesIT.java
+++ b/integration-tests/src/test/java/org/flyte/JavaExamplesIT.java
@@ -16,20 +16,18 @@
  */
 package org.flyte;
 
+import static org.flyte.FlyteContainer.CLIENT;
 import static org.flyte.utils.Literal.ofIntegerMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import flyteidl.core.Literals;
-import org.flyte.utils.FlyteSandboxClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 public class JavaExamplesIT {
-
-  private static final FlyteSandboxClient CLIENT = FlyteSandboxClient.create();
   private static final String CLASSPATH = "flytekit-examples/target/lib";
 
   @BeforeAll

--- a/integration-tests/src/test/java/org/flyte/JavaExamplesIT.java
+++ b/integration-tests/src/test/java/org/flyte/JavaExamplesIT.java
@@ -25,8 +25,10 @@ import flyteidl.core.Literals;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class JavaExamplesIT {
   private static final String CLASSPATH = "flytekit-examples/target/lib";
 

--- a/integration-tests/src/test/java/org/flyte/JavaExamplesIT.java
+++ b/integration-tests/src/test/java/org/flyte/JavaExamplesIT.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import flyteidl.core.Literals;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
@@ -38,10 +37,6 @@ public class JavaExamplesIT {
   }
 
   @Test
-  @Disabled
-  // FIXME doesn't work, seems like a bug in flyteadmin:
-  // Invalid value: "srxnub62yu-orgflyteexamplesSumTask-0": a lowercase RFC 1123 subdomain must
-  // consist of lower case
   public void testSumTask() {
     Literals.LiteralMap output =
         CLIENT.createTaskExecution(

--- a/integration-tests/src/test/java/org/flyte/SerializeJavaIT.java
+++ b/integration-tests/src/test/java/org/flyte/SerializeJavaIT.java
@@ -21,21 +21,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.stream.Stream;
-import org.flyte.utils.FlyteSandboxClient;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class SerializeJavaIT {
   private static final String CLASSPATH = "flytekit-examples/target/lib";
-  @TempDir File tempDir;
+
+  @TempDir Path managed;
 
   @Test
-  @Disabled
   public void testSerializeWorkflows() {
     try {
-      CLIENT.serializeWorkflows(CLASSPATH, tempDir.getAbsolutePath());
+      File current = new File("target/protos");
+      current.mkdir();
+
+      File tempDir = managed.resolve(current.getAbsolutePath()).toFile();
+
+      CLIENT.serializeWorkflows(CLASSPATH, tempDir.getPath());
 
       boolean hasFibonacciWorkflow =
           Stream.of(tempDir.list())

--- a/integration-tests/src/test/java/org/flyte/SerializeJavaIT.java
+++ b/integration-tests/src/test/java/org/flyte/SerializeJavaIT.java
@@ -16,6 +16,7 @@
  */
 package org.flyte;
 
+import static org.flyte.FlyteContainer.CLIENT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -27,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class SerializeJavaIT {
-  private static final FlyteSandboxClient CLIENT = FlyteSandboxClient.create();
   private static final String CLASSPATH = "flytekit-examples/target/lib";
   @TempDir File tempDir;
 

--- a/integration-tests/src/test/java/org/flyte/SerializeJavaIT.java
+++ b/integration-tests/src/test/java/org/flyte/SerializeJavaIT.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,10 @@ public class SerializeJavaIT {
     try {
       File current = new File("target/protos");
       File tempDir = managed.resolve(current.getAbsolutePath()).toFile();
-      boolean mkdir = tempDir.mkdir();
+      boolean created = tempDir.mkdir();
+      if (!created) {
+        throw new IOException("Unable to create path");
+      }
 
       CLIENT.serializeWorkflows(CLASSPATH, tempDir.getPath());
 

--- a/integration-tests/src/test/java/org/flyte/SerializeJavaIT.java
+++ b/integration-tests/src/test/java/org/flyte/SerializeJavaIT.java
@@ -24,8 +24,10 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SerializeJavaIT {
   private static final String CLASSPATH = "flytekit-examples/target/lib";
 
@@ -35,9 +37,8 @@ public class SerializeJavaIT {
   public void testSerializeWorkflows() {
     try {
       File current = new File("target/protos");
-      current.mkdir();
-
       File tempDir = managed.resolve(current.getAbsolutePath()).toFile();
+      boolean mkdir = tempDir.mkdir();
 
       CLIENT.serializeWorkflows(CLASSPATH, tempDir.getPath());
 

--- a/integration-tests/src/test/java/org/flyte/utils/FlyteSandboxContainer.java
+++ b/integration-tests/src/test/java/org/flyte/utils/FlyteSandboxContainer.java
@@ -35,7 +35,11 @@ public class FlyteSandboxContainer extends GenericContainer<FlyteSandboxContaine
 
   public static final String IMAGE_NAME = "ghcr.io/flyteorg/flyte-sandbox:v1.1.0";
 
-  public static final FlyteSandboxContainer INSTANCE = new FlyteSandboxContainer().withReuse(true);
+  public static final FlyteSandboxContainer INSTANCE =
+      new FlyteSandboxContainer()
+          // Note to the developer: to enable test container reuse, please do the following
+          // echo testcontainers.reuse.enable=true > ~/.testcontainers.properties
+          .withReuse(true);
 
   static {
     startContainer();

--- a/integration-tests/src/test/java/org/flyte/utils/FlyteSandboxContainer.java
+++ b/integration-tests/src/test/java/org/flyte/utils/FlyteSandboxContainer.java
@@ -35,7 +35,7 @@ public class FlyteSandboxContainer extends GenericContainer<FlyteSandboxContaine
 
   public static final String IMAGE_NAME = "ghcr.io/flyteorg/flyte-sandbox:v1.1.0";
 
-  public static final FlyteSandboxContainer INSTANCE = new FlyteSandboxContainer();
+  public static final FlyteSandboxContainer INSTANCE = new FlyteSandboxContainer().withReuse(true);
 
   static {
     startContainer();


### PR DESCRIPTION
Signed-off-by: Babis Kiosidis <ckiosidis@gmail.com>
# TL;DR

Set the config in your local environment to reuse the flyte sandbox test container throughout the tests. The config can only be set in the home directory

```
 cat ~/.testcontainers.properties 
testcontainers.reuse.enable=true
```

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
