### PR TITLE
Child only resource discovery

### DIFF
--- a/jflyte/pom.xml
+++ b/jflyte/pom.xml
@@ -168,6 +168,13 @@
       <artifactId>memoryfilesystem</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- ensure there is at least one slf4j implementation in test classpath so that we can test
+         org/slf4j/impl/StaticLoggerBinder.class is only discovered in child class loader -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jflyte/src/test/java/org/flyte/jflyte/ChildFirstClassLoaderTest.java
+++ b/jflyte/src/test/java/org/flyte/jflyte/ChildFirstClassLoaderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.jflyte;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChildFirstClassLoaderTest {
+
+  @Test
+  void testGetResourcesFromChildAndParent() throws Exception {
+    try (URLClassLoader classLoader =
+        new ChildFirstClassLoader(new URL[] {getClass().getResource("/")})) {
+      List<URL> resources = Collections.list(classLoader.getResources(thisClassAsResourceName()));
+
+      assertEquals(2, resources.size());
+    }
+  }
+
+  @Test
+  void testGetResourcesOnlyFromChild() throws IOException {
+    try (URLClassLoader classLoader =
+        new ChildFirstClassLoader(
+            new URL[] {getClass().getResource("/" + thisPackageAsResourceName() + "/")})) {
+      List<URL> resources =
+          Collections.list(classLoader.getResources("org/slf4j/impl/StaticLoggerBinder.class"));
+
+      assertEquals(1, resources.size());
+    }
+  }
+
+  private String thisClassAsResourceName() {
+    return getClass().getName().replace(".", "/") + ".class";
+  }
+
+  private String thisPackageAsResourceName() {
+    return getClass().getPackage().getName().replace(".", "/");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,11 @@
         <version>4.5.13</version>
       </dependency>
       <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.2.3</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>2.13.3</version>


### PR DESCRIPTION
# TL;DR
Configure child only resource discovery to avoid discovering certain resources across class loaders.

## Type
 - [x] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
For certain resources such as `org/slf4j/impl/StaticLoggerBinder.class`, it does not make sense to discovery a parent one because it will almost certain cause classloading problem when mixing parent class and child class.

## Tracking Issue
Closes https://github.com/flyteorg/flyte/issues/3051

## Follow-up issue
_NA_
