### PR TITLE
Bump library versions

### DIFF
--- a/flytekit-scala_2.13/pom.xml
+++ b/flytekit-scala_2.13/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <scala.baseVersion>2.13</scala.baseVersion>
-    <scala.version>2.13.9</scala.version>
+    <scala.version>2.13.10</scala.version>
 
     <magnolia.version>1.0.0-M4</magnolia.version>
 

--- a/jflyte/src/main/java/org/flyte/jflyte/FlyteAdminClient.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/FlyteAdminClient.java
@@ -239,7 +239,7 @@ class FlyteAdminClient implements AutoCloseable {
       // create operation is idempotent, so it's fine to retry
       T response = retries.retry(retryable);
 
-      verifyNotNull(response, "{} {}: Unexpected null response", label, id);
+      verifyNotNull(response, "%s %s: Unexpected null response", label, id);
     } catch (StatusRuntimeException e) {
       // flyteadmin uses ALREADY_EXISTS only if payload is identical, except for executions
       if (e.getStatus().getCode() == Status.Code.ALREADY_EXISTS) {

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
 
   <properties>
     <auto-service.version>1.0.1</auto-service.version>
-    <auto-value.version>1.9</auto-value.version>
-    <common-proto.version>2.9.5</common-proto.version>
+    <auto-value.version>1.10</auto-value.version>
+    <common-proto.version>2.9.6</common-proto.version>
     <grpc.version>1.46.0</grpc.version>
     <!-- must be aligned with netty version -->
     <!-- see: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
@@ -95,7 +95,7 @@
     <sl4j.version>1.7.36</sl4j.version>
     <spotless.version>2.21.0</spotless.version>
     <spotbugs.excludeFilterFile>spotbugs-exclude.xml</spotbugs.excludeFilterFile>
-    <error_prone.version>2.15.0</error_prone.version>
+    <error_prone.version>2.16</error_prone.version>
     <!-- Using the error-prone-javac is required when running on JDK 8 -->
     <error_prone.javac.version>9+181-r4173-1</error_prone.javac.version>
     <junit.version>5.6.2</junit.version>


### PR DESCRIPTION
# TL;DR
Bump library versions suggested by snyk

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Snyk system created the following PRs:
* https://github.com/flyteorg/flytekit-java/pull/141
* https://github.com/flyteorg/flytekit-java/pull/142
* https://github.com/flyteorg/flytekit-java/pull/143
* https://github.com/flyteorg/flytekit-java/pull/144

Closes https://github.com/flyteorg/flytekit-java/pull/141
Closes https://github.com/flyteorg/flytekit-java/pull/142
Closes https://github.com/flyteorg/flytekit-java/pull/143
Closes https://github.com/flyteorg/flytekit-java/pull/144

This PR consolidates all of them and I signed the commits to pass the TCO.

Also fix an error detected by the new version of error prone
## Tracking Issue
_NA_

## Follow-up issue
_NA_
