### PR TITLE
Tweak release procedure a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,5 @@ Also use `git commit --signoff "Commit message"` to comply with DCO.
 
 * Go to [Actions: Create flytekit-java release](https://github.com/flyteorg/flytekit-java/actions/workflows/release.yaml) and click "Run workflow"
 * Wait until the workflow finishes; in the meanwhile prepare a release note
-* Making sure the new release is visible in [Maven central](https://search.maven.org/search?q=a:flytekit-java)
+* Making sure the new release is visible in [Maven central](https://search.maven.org/artifact/org.flyte/flytekit-java)
 * Publish the release note associating with the latest tag created by the release workflow

--- a/README.md
+++ b/README.md
@@ -104,4 +104,7 @@ Also use `git commit --signoff "Commit message"` to comply with DCO.
 
 ## Releasing
 
-Go to [Actions: Create flytekit-java release](https://github.com/flyteorg/flytekit-java/actions/workflows/release.yaml) and click "Run workflow"
+* Go to [Actions: Create flytekit-java release](https://github.com/flyteorg/flytekit-java/actions/workflows/release.yaml) and click "Run workflow"
+* Wait until the workflow finishes; in the meanwhile prepare a release note
+* Making sure the new release is visible in [Maven central](https://search.maven.org/search?q=a:flytekit-java)
+* Publish the release note associating with the latest tag created by the release workflow


### PR DESCRIPTION
# TL;DR
Tweak release procedure a bit.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The way we run maven release results in tag being created first before releasing fully finishes, so we should wait before publishing the release.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
