### PR TITLE
Extends SdkTypes to create sdk types with low overhead

### DIFF
--- a/flytekit-examples/src/main/java/org/flyte/examples/GreetTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/GreetTask.java
@@ -17,17 +17,17 @@
 package org.flyte.examples;
 
 import com.google.auto.service.AutoService;
-import com.google.auto.value.AutoValue;
 import org.flyte.flytekit.SdkBindingData;
 import org.flyte.flytekit.SdkRunnableTask;
 import org.flyte.flytekit.SdkTransform;
-import org.flyte.flytekit.jackson.JacksonSdkType;
+import org.flyte.flytekit.SdkTypes;
 
 /** Example Flyte task that takes a name as the input and outputs a simple greeting message. */
 @AutoService(SdkRunnableTask.class)
-public class GreetTask extends SdkRunnableTask<GreetTask.Input, GreetTask.Output> {
+public class GreetTask extends SdkRunnableTask<String, String> {
   public GreetTask() {
-    super(JacksonSdkType.of(Input.class), JacksonSdkType.of(Output.class));
+    super(
+        SdkTypes.ofPrimitive("name", String.class), SdkTypes.ofPrimitive("greeting", String.class));
   }
 
   /**
@@ -41,41 +41,14 @@ public class GreetTask extends SdkRunnableTask<GreetTask.Input, GreetTask.Output
   }
 
   /**
-   * Generate an immutable value class that represents {@link GreetTask}'s input, which is a String.
-   */
-  @AutoValue
-  public abstract static class Input {
-    public abstract String name();
-  }
-
-  /**
-   * Generate an immutable value class that represents {@link GreetTask}'s output, which is a
-   * String.
-   */
-  @AutoValue
-  public abstract static class Output {
-    public abstract String greeting();
-
-    /**
-     * Wraps the constructor of the generated output value class.
-     *
-     * @param greeting the String literal output of {@link GreetTask}
-     * @return output of GreetTask
-     */
-    public static Output create(String greeting) {
-      return new AutoValue_GreetTask_Output(greeting);
-    }
-  }
-
-  /**
-   * Defines task behavior. This task takes a name as the input, wraps it in a welcome message, and
-   * outputs the message.
+   * Defines task behavior. This task takes a name as the input, compose a welcome message, and
+   * returns it.
    *
-   * @param input the name of the person to be greeted
+   * @param name the name of the person to be greeted
    * @return the welcome message
    */
   @Override
-  public Output run(Input input) {
-    return Output.create(String.format("Welcome, %s!", input.name()));
+  public String run(String name) {
+    return String.format("Welcome, %s!", name);
   }
 }

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkTypes.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkTypes.java
@@ -271,7 +271,7 @@ public class SdkTypes {
 
     switch (fieldType.simpleType()) {
       case INTEGER:
-        return Struct.Value.ofNumberValue(literal.scalar().primitive().integerValue());
+        return Struct.Value.ofNumberValue((double) literal.scalar().primitive().integerValue());
       case FLOAT:
         return Struct.Value.ofNumberValue(literal.scalar().primitive().floatValue());
       case STRING:

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkTypes.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkTypes.java
@@ -16,9 +16,21 @@
  */
 package org.flyte.flytekit;
 
+import static java.util.Collections.singletonMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.AbstractMap;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.flyte.api.v1.Literal;
+import org.flyte.api.v1.LiteralType;
 import org.flyte.api.v1.Variable;
 
 /** An utility class for creating {@link SdkType} objects for different types. */
@@ -44,6 +56,169 @@ public class SdkTypes {
     @Override
     public Map<String, Variable> getVariableMap() {
       return Collections.emptyMap();
+    }
+  }
+
+  // private custom class instead of autovalue to hide everything
+  private static class TypeToLiteralTypeDef<T> {
+    final Function<T, Literal> toLiteral;
+    final Function<Literal, T> toValue;
+    final LiteralType type;
+
+    private TypeToLiteralTypeDef(
+        Function<T, Literal> toLiteral, Function<Literal, T> toValue, LiteralType type) {
+      this.toLiteral = toLiteral;
+      this.toValue = toValue;
+      this.type = type;
+    }
+  }
+
+  private static final Map<Class<?>, TypeToLiteralTypeDef<?>> TYPE_MAP;
+
+  static {
+    Map<Class<?>, TypeToLiteralTypeDef<?>> typeMap = new HashMap<>();
+    typeMap.put(
+        Long.class,
+        new TypeToLiteralTypeDef<>(
+            Literals::ofInteger, l -> l.scalar().primitive().integerValue(), LiteralTypes.INTEGER));
+    typeMap.put(
+        Double.class,
+        new TypeToLiteralTypeDef<>(
+            Literals::ofFloat, l -> l.scalar().primitive().floatValue(), LiteralTypes.FLOAT));
+    typeMap.put(
+        String.class,
+        new TypeToLiteralTypeDef<>(
+            Literals::ofString, l -> l.scalar().primitive().stringValue(), LiteralTypes.STRING));
+    typeMap.put(
+        Boolean.class,
+        new TypeToLiteralTypeDef<>(
+            Literals::ofBoolean, l -> l.scalar().primitive().booleanValue(), LiteralTypes.BOOLEAN));
+    typeMap.put(
+        Instant.class,
+        new TypeToLiteralTypeDef<>(
+            Literals::ofDatetime, l -> l.scalar().primitive().datetime(), LiteralTypes.DATETIME));
+    typeMap.put(
+        Duration.class,
+        new TypeToLiteralTypeDef<>(
+            Literals::ofDuration, l -> l.scalar().primitive().duration(), LiteralTypes.DURATION));
+
+    TYPE_MAP = typeMap;
+  }
+
+  public static <T> SdkType<T> ofPrimitive(String varName, Class<T> clazz) {
+    TypeToLiteralTypeDef<T> typeToLiteralTypeDef = getDef(clazz);
+    return new SdkLiteralType<>(requireNonNull(varName), typeToLiteralTypeDef);
+  }
+
+  public static <T> SdkType<List<T>> ofCollection(String varName, Class<T> clazz) {
+    TypeToLiteralTypeDef<T> typeToLiteralTypeDef = getDef(clazz);
+    return new SdkCollectionType<>(varName, typeToLiteralTypeDef);
+  }
+
+  public static <T> SdkType<Map<String, T>> ofMap(String varName, Class<T> clazz) {
+    TypeToLiteralTypeDef<T> typeToLiteralTypeDef = getDef(clazz);
+    return new SdkMapType<>(varName, typeToLiteralTypeDef);
+  }
+
+  private static <T> TypeToLiteralTypeDef<T> getDef(Class<T> clazz) {
+    if (!TYPE_MAP.containsKey(clazz)) {
+      String errMessage = String.format("Type [%s] is not a supported literal type", clazz);
+      throw new IllegalArgumentException(errMessage);
+    }
+    @SuppressWarnings("unchecked")
+    TypeToLiteralTypeDef<T> typeToLiteralTypeDef = (TypeToLiteralTypeDef<T>) TYPE_MAP.get(clazz);
+    return typeToLiteralTypeDef;
+  }
+
+  private static class SdkLiteralType<T> extends SdkType<T> {
+    private final String varName;
+    private final TypeToLiteralTypeDef<T> typeDef;
+
+    private SdkLiteralType(String varName, TypeToLiteralTypeDef<T> typeDef) {
+      this.varName = varName;
+      this.typeDef = typeDef;
+    }
+
+    @Override
+    public Map<String, Literal> toLiteralMap(T value) {
+      return singletonMap(varName, typeDef.toLiteral.apply(value));
+    }
+
+    @Override
+    public T fromLiteralMap(Map<String, Literal> map) {
+      return typeDef.toValue.apply(map.get(varName));
+    }
+
+    @Override
+    public Map<String, Variable> getVariableMap() {
+      return singletonMap(varName, Variable.builder().literalType(typeDef.type).build());
+    }
+  }
+
+  private static class SdkCollectionType<T> extends SdkType<List<T>> {
+    private final String varName;
+    private final TypeToLiteralTypeDef<T> typeDef;
+
+    private SdkCollectionType(String varName, TypeToLiteralTypeDef<T> typeDef) {
+      this.varName = varName;
+      this.typeDef = typeDef;
+    }
+
+    @Override
+    public Map<String, Literal> toLiteralMap(List<T> values) {
+
+      List<Literal> collection = values.stream().map(typeDef.toLiteral).collect(toList());
+      return singletonMap(varName, Literal.ofCollection(collection));
+    }
+
+    @Override
+    public List<T> fromLiteralMap(Map<String, Literal> map) {
+      Literal collection = map.get(varName);
+      return collection.collection().stream().map(typeDef.toValue).collect(toList());
+    }
+
+    @Override
+    public Map<String, Variable> getVariableMap() {
+      return singletonMap(
+          varName,
+          Variable.builder().literalType(LiteralType.ofCollectionType(typeDef.type)).build());
+    }
+  }
+
+  private static class SdkMapType<T> extends SdkType<Map<String, T>> {
+    private final String varName;
+    private final TypeToLiteralTypeDef<T> typeDef;
+
+    private SdkMapType(String varName, TypeToLiteralTypeDef<T> typeDef) {
+      this.varName = varName;
+      this.typeDef = typeDef;
+    }
+
+    @Override
+    public Map<String, Literal> toLiteralMap(Map<String, T> values) {
+      Map<String, Literal> map =
+          values.entrySet().stream()
+              .map(
+                  e ->
+                      new AbstractMap.SimpleEntry<>(
+                          e.getKey(), typeDef.toLiteral.apply(e.getValue())))
+              .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+      return singletonMap(varName, Literal.ofMap(map));
+    }
+
+    @Override
+    public Map<String, T> fromLiteralMap(Map<String, Literal> map) {
+      Literal collection = map.get(varName);
+      return collection.map().entrySet().stream()
+          .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), typeDef.toValue.apply(e.getValue())))
+          .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Variable> getVariableMap() {
+      return singletonMap(
+          varName,
+          Variable.builder().literalType(LiteralType.ofMapValueType(typeDef.type)).build());
     }
   }
 }

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkTypes.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkTypes.java
@@ -467,6 +467,7 @@ public class SdkTypes {
   // TODO: Remove this class when compiling with Java 11 and we can use Map.entry()
   // using new AbstractMap.SimpleEntry directly is too verbose
   private static class MapEntry<T> extends AbstractMap.SimpleEntry<String, T> {
+    private static final long serialVersionUID = -6119015712388978761L;
 
     private MapEntry(String key, T value) {
       super(key, value);

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkTypesTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkTypesTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit;
+
+import static java.time.ZoneOffset.UTC;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.flyte.api.v1.Literal;
+import org.flyte.api.v1.LiteralType;
+import org.flyte.api.v1.Variable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SdkTypesTest {
+
+  public static final String PARAM_NAME = "it";
+  public static final Instant INSTANT = ZonedDateTime.now(UTC).toInstant();
+
+  @Test
+  void testNullsType() {
+    SdkType<Void> sdkType = SdkTypes.nulls();
+
+    assertNull(sdkType.fromLiteralMap(emptyMap()));
+    assertEquals(emptyMap(), sdkType.toLiteralMap(null));
+    assertEquals(emptyMap(), sdkType.getVariableMap());
+  }
+
+  @ParameterizedTest(name = "literal type of {0}")
+  @MethodSource("testOfPrimitiveProvider")
+  <T> void testOfPrimitive(
+      Class<T> clazz,
+      T value,
+      Map<String, Literal> literalMap,
+      Map<String, Variable> expectedVariableMap) {
+    SdkType<T> sdkType = SdkTypes.ofPrimitive(PARAM_NAME, clazz);
+
+    assertEquals(value, sdkType.fromLiteralMap(literalMap));
+    assertEquals(literalMap, sdkType.toLiteralMap(value));
+    assertEquals(expectedVariableMap, sdkType.getVariableMap());
+  }
+
+  public static Stream<Arguments> testOfPrimitiveProvider() {
+    return Stream.of(
+        arguments(
+            Long.class, 42L, literalMap(Literals.ofInteger(42)), varMap(LiteralTypes.INTEGER)),
+        arguments(Double.class, 4.0, literalMap(Literals.ofFloat(4.0)), varMap(LiteralTypes.FLOAT)),
+        arguments(
+            String.class, "foo", literalMap(Literals.ofString("foo")), varMap(LiteralTypes.STRING)),
+        arguments(
+            Boolean.class,
+            true,
+            literalMap(Literals.ofBoolean(true)),
+            varMap(LiteralTypes.BOOLEAN)),
+        arguments(
+            Instant.class,
+            INSTANT,
+            literalMap(Literals.ofDatetime(INSTANT)),
+            varMap(LiteralTypes.DATETIME)),
+        arguments(
+            Duration.class,
+            Duration.ofHours(1),
+            literalMap(Literals.ofDuration(Duration.ofHours(1))),
+            varMap(LiteralTypes.DURATION)));
+  }
+
+  @ParameterizedTest(name = "literal type of {0}")
+  @MethodSource("testOfCollectionProvider")
+  <T> void testOfCollection(
+      Class<T> clazz,
+      List<T> values,
+      Map<String, Literal> literalMap,
+      Map<String, Variable> expectedVariableMap) {
+    SdkType<List<T>> sdkType = SdkTypes.ofCollection(PARAM_NAME, clazz);
+
+    assertEquals(values, sdkType.fromLiteralMap(literalMap));
+    assertEquals(literalMap, sdkType.toLiteralMap(values));
+    assertEquals(expectedVariableMap, sdkType.getVariableMap());
+  }
+
+  public static Stream<Arguments> testOfCollectionProvider() {
+    return Stream.of(
+        arguments(
+            Long.class,
+            Arrays.asList(1L, 2L, 3L),
+            literalMap(
+                Arrays.asList(
+                    Literals.ofInteger(1L), Literals.ofInteger(2L), Literals.ofInteger(3L))),
+            varMapForCollection(LiteralTypes.INTEGER)),
+        arguments(
+            Double.class,
+            Arrays.asList(1.5, 2.5, 3.5),
+            literalMap(
+                Arrays.asList(Literals.ofFloat(1.5), Literals.ofFloat(2.5), Literals.ofFloat(3.5))),
+            varMapForCollection(LiteralTypes.FLOAT)));
+  }
+
+  @ParameterizedTest(name = "literal type of {0}")
+  @MethodSource("testOfMapProvider")
+  <T> void testOfMap(
+      Class<T> clazz,
+      Map<String, T> values,
+      Map<String, Literal> literalMap,
+      Map<String, Variable> expectedVariableMap) {
+    SdkType<Map<String, T>> sdkType = SdkTypes.ofMap(PARAM_NAME, clazz);
+
+    assertEquals(values, sdkType.fromLiteralMap(literalMap));
+    assertEquals(literalMap, sdkType.toLiteralMap(values));
+    assertEquals(expectedVariableMap, sdkType.getVariableMap());
+  }
+
+  public static Stream<Arguments> testOfMapProvider() {
+    return Stream.of(
+        arguments(
+            Instant.class,
+            singletonMap("foo", INSTANT),
+            literalMap(singletonMap("foo", Literals.ofDatetime(INSTANT))),
+            varMapForMap(LiteralTypes.DATETIME)),
+        arguments(
+            Duration.class,
+            singletonMap("foo", Duration.ofDays(1)),
+            literalMap(singletonMap("foo", Literals.ofDuration(Duration.ofDays(1)))),
+            varMapForMap(LiteralTypes.DURATION)));
+  }
+
+  @Test
+  void testOfPrimitiveWithUnsupportedClass() {
+    Exception ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> SdkTypes.ofPrimitive("in", UnSupportedLiteralClass.class));
+
+    assertEquals(
+        "Type [class org.flyte.flytekit.SdkTypesTest$UnSupportedLiteralClass] is not a supported literal type",
+        ex.getMessage());
+  }
+
+  @Test
+  void testOfCollectionLiteralWithUnsupportedClass() {
+    Exception ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> SdkTypes.ofCollection("in", UnSupportedLiteralClass.class));
+
+    assertEquals(
+        "Type [class org.flyte.flytekit.SdkTypesTest$UnSupportedLiteralClass] is not a supported literal type",
+        ex.getMessage());
+  }
+
+  @Test
+  void testOfMapLiteralWithUnsupportedClass() {
+    Exception ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> SdkTypes.ofMap("in", UnSupportedLiteralClass.class));
+
+    assertEquals(
+        "Type [class org.flyte.flytekit.SdkTypesTest$UnSupportedLiteralClass] is not a supported literal type",
+        ex.getMessage());
+  }
+
+  private static Map<String, Literal> literalMap(Literal value) {
+    return singletonMap(PARAM_NAME, value);
+  }
+
+  private static Map<String, Literal> literalMap(List<Literal> values) {
+    return singletonMap(PARAM_NAME, Literal.ofCollection(values));
+  }
+
+  private static Map<String, Literal> literalMap(Map<String, Literal> values) {
+    return singletonMap(PARAM_NAME, Literal.ofMap(values));
+  }
+
+  private static Map<String, Variable> varMap(LiteralType literalType) {
+    return singletonMap(PARAM_NAME, Variable.builder().literalType(literalType).build());
+  }
+
+  private static Map<String, Variable> varMapForCollection(LiteralType literalType) {
+    return singletonMap(
+        PARAM_NAME,
+        Variable.builder().literalType(LiteralType.ofCollectionType(literalType)).build());
+  }
+
+  private static Map<String, Variable> varMapForMap(LiteralType literalType) {
+    return singletonMap(
+        PARAM_NAME,
+        Variable.builder().literalType(LiteralType.ofMapValueType(literalType)).build());
+  }
+
+  static class UnSupportedLiteralClass {}
+}

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkTypesTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkTypesTest.java
@@ -18,21 +18,29 @@ package org.flyte.flytekit;
 
 import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import com.google.auto.value.AutoValue;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.flyte.api.v1.Literal;
 import org.flyte.api.v1.LiteralType;
+import org.flyte.api.v1.Scalar;
+import org.flyte.api.v1.SchemaType;
+import org.flyte.api.v1.Struct;
 import org.flyte.api.v1.Variable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -150,6 +158,128 @@ class SdkTypesTest {
             varMapForMap(LiteralTypes.DURATION)));
   }
 
+  @Test()
+  void testOfStruct() {
+    CustomStructSdkType sdkType = new CustomStructSdkType();
+    CustomStruct customStruct =
+        CustomStruct.create(123, 4.56, "789", true, INSTANT, Duration.ofMinutes(3));
+
+    Map<String, Struct.Value> strucLiteralMapFields = new HashMap<>();
+    strucLiteralMapFields.put("i", Struct.Value.ofNumberValue(123));
+    strucLiteralMapFields.put("f", Struct.Value.ofNumberValue(4.56));
+    strucLiteralMapFields.put("s", Struct.Value.ofStringValue("789"));
+    strucLiteralMapFields.put("b", Struct.Value.ofBoolValue(true));
+    strucLiteralMapFields.put("dt", Struct.Value.ofStringValue(INSTANT.toString()));
+    strucLiteralMapFields.put("d", Struct.Value.ofStringValue(Duration.ofMinutes(3).toString()));
+    Map<String, Literal> structLiteralMap =
+        singletonMap(
+            PARAM_NAME, Literal.ofScalar(Scalar.ofGeneric(Struct.of(strucLiteralMapFields))));
+
+    List<SchemaType.Column> columns = new ArrayList<>();
+    columns.add(column("i", SchemaType.ColumnType.INTEGER));
+    columns.add(column("f", SchemaType.ColumnType.FLOAT));
+    columns.add(column("s", SchemaType.ColumnType.STRING));
+    columns.add(column("b", SchemaType.ColumnType.BOOLEAN));
+    columns.add(column("dt", SchemaType.ColumnType.DATETIME));
+    columns.add(column("d", SchemaType.ColumnType.DURATION));
+    Map<String, Variable> structVariableMap =
+        singletonMap(
+            PARAM_NAME,
+            variable(LiteralType.ofSchemaType(SchemaType.builder().columns(columns).build())));
+
+    SdkType<CustomStruct> structType = SdkTypes.ofStruct(PARAM_NAME, sdkType);
+
+    assertEquals(customStruct, structType.fromLiteralMap(structLiteralMap));
+    assertEquals(structLiteralMap, structType.toLiteralMap(customStruct));
+    assertEquals(structVariableMap, structType.getVariableMap());
+  }
+
+  @Test()
+  void testOfStructCollection() {
+    CustomStructSdkType sdkType = new CustomStructSdkType();
+    CustomStruct customStruct =
+        CustomStruct.create(123, 4.56, "789", true, INSTANT, Duration.ofMinutes(3));
+
+    Map<String, Struct.Value> strucLiteralMapFields = new HashMap<>();
+    strucLiteralMapFields.put("i", Struct.Value.ofNumberValue(123));
+    strucLiteralMapFields.put("f", Struct.Value.ofNumberValue(4.56));
+    strucLiteralMapFields.put("s", Struct.Value.ofStringValue("789"));
+    strucLiteralMapFields.put("b", Struct.Value.ofBoolValue(true));
+    strucLiteralMapFields.put("dt", Struct.Value.ofStringValue(INSTANT.toString()));
+    strucLiteralMapFields.put("d", Struct.Value.ofStringValue(Duration.ofMinutes(3).toString()));
+    Map<String, Literal> structLiteralMap =
+        singletonMap(
+            PARAM_NAME,
+            Literal.ofCollection(
+                singletonList(
+                    Literal.ofScalar(Scalar.ofGeneric(Struct.of(strucLiteralMapFields))))));
+
+    List<SchemaType.Column> columns = new ArrayList<>();
+    columns.add(column("i", SchemaType.ColumnType.INTEGER));
+    columns.add(column("f", SchemaType.ColumnType.FLOAT));
+    columns.add(column("s", SchemaType.ColumnType.STRING));
+    columns.add(column("b", SchemaType.ColumnType.BOOLEAN));
+    columns.add(column("dt", SchemaType.ColumnType.DATETIME));
+    columns.add(column("d", SchemaType.ColumnType.DURATION));
+    Map<String, Variable> structVariableMap =
+        singletonMap(
+            PARAM_NAME,
+            variable(
+                LiteralType.ofCollectionType(
+                    LiteralType.ofSchemaType(SchemaType.builder().columns(columns).build()))));
+
+    SdkType<List<CustomStruct>> structType = SdkTypes.ofCollection(PARAM_NAME, sdkType);
+
+    assertEquals(singletonList(customStruct), structType.fromLiteralMap(structLiteralMap));
+    assertEquals(structLiteralMap, structType.toLiteralMap(singletonList(customStruct)));
+    assertEquals(structVariableMap, structType.getVariableMap());
+  }
+
+  @Test()
+  void testOfStructMap() {
+    CustomStructSdkType sdkType = new CustomStructSdkType();
+    CustomStruct customStruct =
+        CustomStruct.create(123, 4.56, "789", true, INSTANT, Duration.ofMinutes(3));
+
+    Map<String, Struct.Value> strucLiteralMapFields = new HashMap<>();
+    strucLiteralMapFields.put("i", Struct.Value.ofNumberValue(123));
+    strucLiteralMapFields.put("f", Struct.Value.ofNumberValue(4.56));
+    strucLiteralMapFields.put("s", Struct.Value.ofStringValue("789"));
+    strucLiteralMapFields.put("b", Struct.Value.ofBoolValue(true));
+    strucLiteralMapFields.put("dt", Struct.Value.ofStringValue(INSTANT.toString()));
+    strucLiteralMapFields.put("d", Struct.Value.ofStringValue(Duration.ofMinutes(3).toString()));
+    Map<String, Literal> structLiteralMap =
+        singletonMap(
+            PARAM_NAME,
+            Literal.ofMap(
+                singletonMap(
+                    "foo", Literal.ofScalar(Scalar.ofGeneric(Struct.of(strucLiteralMapFields))))));
+
+    List<SchemaType.Column> columns = new ArrayList<>();
+    columns.add(column("i", SchemaType.ColumnType.INTEGER));
+    columns.add(column("f", SchemaType.ColumnType.FLOAT));
+    columns.add(column("s", SchemaType.ColumnType.STRING));
+    columns.add(column("b", SchemaType.ColumnType.BOOLEAN));
+    columns.add(column("dt", SchemaType.ColumnType.DATETIME));
+    columns.add(column("d", SchemaType.ColumnType.DURATION));
+    Map<String, Variable> structVariableMap =
+        singletonMap(
+            PARAM_NAME,
+            variable(
+                LiteralType.ofMapValueType(
+                    LiteralType.ofSchemaType(SchemaType.builder().columns(columns).build()))));
+
+    SdkType<Map<String, CustomStruct>> structType = SdkTypes.ofMap(PARAM_NAME, sdkType);
+
+    assertEquals(singletonMap("foo", customStruct), structType.fromLiteralMap(structLiteralMap));
+    assertEquals(structLiteralMap, structType.toLiteralMap(singletonMap("foo", customStruct)));
+    assertEquals(structVariableMap, structType.getVariableMap());
+  }
+
+  private static SchemaType.Column column(String name, SchemaType.ColumnType columnType) {
+    return SchemaType.Column.builder().name(name).type(columnType).build();
+  }
+
   @Test
   void testOfPrimitiveWithUnsupportedClass() {
     Exception ex =
@@ -199,20 +329,79 @@ class SdkTypesTest {
   }
 
   private static Map<String, Variable> varMap(LiteralType literalType) {
-    return singletonMap(PARAM_NAME, Variable.builder().literalType(literalType).build());
+    return singletonMap(PARAM_NAME, variable(literalType));
   }
 
   private static Map<String, Variable> varMapForCollection(LiteralType literalType) {
-    return singletonMap(
-        PARAM_NAME,
-        Variable.builder().literalType(LiteralType.ofCollectionType(literalType)).build());
+    return singletonMap(PARAM_NAME, variable(LiteralType.ofCollectionType(literalType)));
   }
 
   private static Map<String, Variable> varMapForMap(LiteralType literalType) {
-    return singletonMap(
-        PARAM_NAME,
-        Variable.builder().literalType(LiteralType.ofMapValueType(literalType)).build());
+    return singletonMap(PARAM_NAME, variable(LiteralType.ofMapValueType(literalType)));
   }
 
-  static class UnSupportedLiteralClass {}
+  private static Variable variable(LiteralType literalType) {
+    return Variable.builder().literalType(literalType).build();
+  }
+
+  private static class UnSupportedLiteralClass {}
+
+  @AutoValue
+  abstract static class CustomStruct {
+    abstract long i();
+
+    abstract double f();
+
+    abstract String s();
+
+    abstract boolean b();
+
+    abstract Instant dt();
+
+    abstract Duration d();
+
+    public static CustomStruct create(
+        long i, double f, String s, boolean b, Instant dt, Duration d) {
+      return new AutoValue_SdkTypesTest_CustomStruct(i, f, s, b, dt, d);
+    }
+  }
+
+  // Creating a custom SdkType for CustomStruct to avoid cyclic dependency with JacksonSdkType
+  private static class CustomStructSdkType extends SdkType<CustomStruct> {
+
+    @Override
+    public Map<String, Literal> toLiteralMap(CustomStruct value) {
+      Map<String, Literal> literals = new LinkedHashMap<>(); // keep insertion order for debugging
+      literals.put("i", Literals.ofInteger(value.i()));
+      literals.put("f", Literals.ofFloat(value.f()));
+      literals.put("s", Literals.ofString(value.s()));
+      literals.put("b", Literals.ofBoolean(value.b()));
+      literals.put("dt", Literals.ofDatetime(value.dt()));
+      literals.put("d", Literals.ofDuration(value.d()));
+      return literals;
+    }
+
+    @Override
+    public CustomStruct fromLiteralMap(Map<String, Literal> value) {
+      return CustomStruct.create(
+          value.get("i").scalar().primitive().integerValue(),
+          value.get("f").scalar().primitive().floatValue(),
+          value.get("s").scalar().primitive().stringValue(),
+          value.get("b").scalar().primitive().booleanValue(),
+          value.get("dt").scalar().primitive().datetime(),
+          value.get("d").scalar().primitive().duration());
+    }
+
+    @Override
+    public Map<String, Variable> getVariableMap() {
+      Map<String, Variable> variables = new LinkedHashMap<>(); // keep insertion order for debugging
+      variables.put("i", variable(LiteralTypes.INTEGER));
+      variables.put("f", variable(LiteralTypes.FLOAT));
+      variables.put("s", variable(LiteralTypes.STRING));
+      variables.put("b", variable(LiteralTypes.BOOLEAN));
+      variables.put("dt", variable(LiteralTypes.DATETIME));
+      variables.put("d", variable(LiteralTypes.DURATION));
+      return variables;
+    }
+  }
 }


### PR DESCRIPTION
# TL;DR
Extends SdkTypes to create `SdkType<T>` with low overhead

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Currently the way to create custom `SdkType<T>` in Java is using `JacksonSdkType`. For example

If a developer wants to define a task equivalent to `(String str) -> str.toUpperCase()` currently he/she needs to write it as

```java
@AutoService(SdkRunnableTask.class)
public class ToUpperCaseTask extends SdkRunnableTask<ToUpperCaseTask.Input, ToUpperCaseTask.Output> {
  public ToUpperCaseTask() {
    super(JacksonSdkType.of(Input.class), JacksonSdkType.of(Output.class));
  }

  @AutoValue
  public abstract static class Input {
    public abstract String in();
  }

  @AutoValue
  public abstract static class Output {
    public abstract String out();

    public static Output create(String out) {
      return new AutoValue_ToUpperCaseTask_Output(out);
    }
  }

  @Override
  public Output run(Input input) {
    return Output.create(input.toUpperCase()));
  }
}
```
For such trivial task, defining the AutoValues to define the types takes the majority of the lines.

With this PR the developer could write the task this way instead
```java
@AutoService(SdkRunnableTask.class)
public class ToUpperCaseTask extends SdkRunnableTask<String, String> {
  public ToUpperCaseTask() {
    super(SdkTypes.ofPrimitive("in", String.class), SdkTypes.ofPrimitive("out", String.class));
  }

  @Override
  public String run(String input) {
    return input.toUpperCase();
  }
}
```

Defining the types for the task now takes one line only and the `run` is simplified too as no need to create or access AutoValues

This PR supports creating simplified `SdkType`s for the following types:
* `SdkTypes.ofPrimitive("in", Long.class)` for `SdkType<Long>`
* `SdkTypes.ofPrimitive("in", Double.class)` for `SdkType<Double>`
* `SdkTypes.ofPrimitive("in", String.class)` for `SdkType<String>`
* `SdkTypes.ofPrimitive("in", Boolean.class)` for `SdkType<Boolean>`
* `SdkTypes.ofPrimitive("in", Instant.class)` for `SdkType<Instant>`
* `SdkTypes.ofPrimitive("in", Duration.class)` for `SdkType<Duration>`

Also support for collection and map for the the same primitive types:

* `SdkTypes.ofCollection("in", Long.class)` for `SdkType<List<Long>>`
* `SdkTypes.ofMap("in", Long.class)` for `SdkType<Map<String, Long>>`

And finally support for struts, collection of structs and map of struts:
* `SdkTypes.ofStruct("in", JacksonSdkType.of(Input.class))` for `SdkType<Input>`
* `SdkTypes.ofCollection("in", JacksonSdkType.of(Input.class))` for `SdkType<List<Input>>`
* `SdkTypes.ofMap("in", JacksonSdkType.of(Input.class))` for `SdkType<Map<String, Input>>`
