### PR TITLE
[Breaking change] Target Java 11

### DIFF
--- a/flyteidl-protos/pom.xml
+++ b/flyteidl-protos/pom.xml
@@ -42,6 +42,10 @@
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,9 @@
     <error-prone-base-config><![CDATA[-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/generated-(test-)?sources/.*]]></error-prone-base-config>
     <error-prone-additional-args>-Xep:AutoValueImmutableFields:OFF -Xep:Var:ERROR</error-prone-additional-args>
 
-    <!-- Keep generated .class files java 8 compatible -->
-    <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
   </properties>
 
   <dependencyManagement>
@@ -301,6 +302,11 @@
         <version>1.2.3</version>
       </dependency>
       <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>2.13.3</version>
@@ -353,8 +359,6 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
           <configuration>
-            <source>8</source>
-            <target>8</target>
             <showWarnings>true</showWarnings>
             <showDeprecation>true</showDeprecation>
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
@@ -629,7 +633,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>4.5.6</version>
+          <version>4.7.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
# TL;DR
Target Java 11

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

I also verified locally after doing a clean compilation, bot for Java and Scala.

## Complete description
Target Java 11 and dropping Java 8 support.

Note that for Scala 2.12 we are still targeting Java 8 for backward compatibility.

This page lists JDK compatibility of Scala: https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html

## Tracking Issue

Closes https://github.com/flyteorg/flyte/issues/3147

## Follow-up issue
_NA_
