### PR TITLE
Add support for empty Lists and empty Maps

### DIFF
--- a/flytekit-examples/src/main/java/org/flyte/examples/AllInputsTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/AllInputsTask.java
@@ -16,6 +16,9 @@
  */
 package org.flyte.examples;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+
 import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
 import java.time.Duration;
@@ -43,16 +46,20 @@ public class AllInputsTask
       SdkBindingData<Instant> t,
       SdkBindingData<Duration> d,
       SdkBindingData<List<String>> l,
-      SdkBindingData<Map<String, String>> m) {
+      SdkBindingData<Map<String, String>> m,
+      SdkBindingData<List<String>> emptyList,
+      SdkBindingData<Map<String, Long>> emptyMap) {
     return new AllInputsTask()
-        .withInput("i", i) // this still sucks
+        .withInput("i", i)
         .withInput("f", f)
         .withInput("s", s)
         .withInput("b", b)
         .withInput("t", t)
         .withInput("d", d)
         .withInput("l", l)
-        .withInput("m", m);
+        .withInput("m", m)
+        .withInput("emptyList", emptyList)
+        .withInput("emptyMap", emptyMap);
   }
 
   @AutoValue
@@ -76,6 +83,10 @@ public class AllInputsTask
 
     public abstract SdkBindingData<Map<String, String>> m();
 
+    public abstract SdkBindingData<List<String>> emptyList();
+
+    public abstract SdkBindingData<Map<String, Long>> emptyMap();
+
     public static AutoAllInputsInput create(
         SdkBindingData<Long> i,
         SdkBindingData<Double> f,
@@ -85,8 +96,11 @@ public class AllInputsTask
         SdkBindingData<Duration> d,
         // Blob blob,
         SdkBindingData<List<String>> l,
-        SdkBindingData<Map<String, String>> m) {
-      return new AutoValue_AllInputsTask_AutoAllInputsInput(i, f, s, b, t, d, l, m);
+        SdkBindingData<Map<String, String>> m,
+        SdkBindingData<List<String>> emptyList,
+        SdkBindingData<Map<String, Long>> emptyMap) {
+      return new AutoValue_AllInputsTask_AutoAllInputsInput(
+          i, f, s, b, t, d, l, m, emptyList, emptyMap);
     }
   }
 
@@ -112,6 +126,10 @@ public class AllInputsTask
 
     public abstract SdkBindingData<Map<String, String>> m();
 
+    public abstract SdkBindingData<List<String>> emptyList();
+
+    public abstract SdkBindingData<Map<String, Long>> emptyMap();
+
     public static AutoAllInputsOutput create(
         long i,
         Double f,
@@ -120,7 +138,9 @@ public class AllInputsTask
         Instant t,
         Duration d,
         List<String> l,
-        Map<String, String> m) {
+        Map<String, String> m,
+        List<String> emptyList,
+        Map<String, Long> emptyMap) {
       return new AutoValue_AllInputsTask_AutoAllInputsOutput(
           SdkBindingData.ofInteger(i),
           SdkBindingData.ofFloat(f),
@@ -128,8 +148,10 @@ public class AllInputsTask
           SdkBindingData.ofBoolean(b),
           SdkBindingData.ofDatetime(t),
           SdkBindingData.ofDuration(d),
-          SdkBindingData.ofCollection(l, SdkBindingData::ofString),
-          SdkBindingData.ofMap(m, SdkBindingData::ofString));
+          SdkBindingData.ofStringCollection(l),
+          SdkBindingData.ofStringMap(m),
+          SdkBindingData.ofStringCollection(emptyList),
+          SdkBindingData.ofIntegerMap(emptyMap));
     }
   }
 
@@ -143,7 +165,9 @@ public class AllInputsTask
         input.t().get(),
         input.d().get(),
         input.l().get(),
-        input.m().get());
+        input.m().get(),
+        input.emptyList().get(),
+        input.emptyMap().get());
   }
 
   @Override

--- a/flytekit-examples/src/main/java/org/flyte/examples/AllInputsWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/AllInputsWorkflow.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.flyte.examples.AllInputsTask.AutoAllInputsOutput;
@@ -54,8 +55,10 @@ public class AllInputsWorkflow extends SdkWorkflow<AllInputsWorkflow.AllInputsWo
                 SdkBindingData.ofBoolean(true),
                 SdkBindingData.ofDatetime(cal.toInstant()),
                 SdkBindingData.ofDuration(Duration.ofDays(1L)),
-                SdkBindingData.ofCollection(Arrays.asList("foo", "bar"), SdkBindingData::ofString),
-                SdkBindingData.ofMap(Map.of("test", "test"), SdkBindingData::ofString)));
+                SdkBindingData.ofStringCollection(Arrays.asList("foo", "bar")),
+                SdkBindingData.ofStringMap(Map.of("test", "test")),
+                SdkBindingData.ofStringCollection(Collections.emptyList()),
+                SdkBindingData.ofIntegerMap(Collections.emptyMap())));
     AllInputsTask.AutoAllInputsOutput outputs = apply.getOutputs();
 
     builder.output("i", outputs.i(), "Integer value");
@@ -66,6 +69,8 @@ public class AllInputsWorkflow extends SdkWorkflow<AllInputsWorkflow.AllInputsWo
     builder.output("d", outputs.d(), "Duration value");
     builder.output("l", outputs.l(), "List value");
     builder.output("m", outputs.m(), "Map value");
+    builder.output("emptyList", outputs.emptyList(), "Empty list value");
+    builder.output("emptyMap", outputs.emptyMap(), "Empty map value");
   }
 
   @AutoValue
@@ -90,6 +95,10 @@ public class AllInputsWorkflow extends SdkWorkflow<AllInputsWorkflow.AllInputsWo
 
     public abstract SdkBindingData<Map<String, String>> m();
 
+    public abstract SdkBindingData<List<String>> emptyList();
+
+    public abstract SdkBindingData<Map<String, Long>> emptyMap();
+
     public static AllInputsWorkflow.AllInputsWorkflowOutput create(
         long i,
         Double f,
@@ -98,7 +107,9 @@ public class AllInputsWorkflow extends SdkWorkflow<AllInputsWorkflow.AllInputsWo
         Instant t,
         Duration d,
         List<String> l,
-        Map<String, String> m) {
+        Map<String, String> m,
+        List<String> emptyList,
+        Map<String, Long> emptyMap) {
       return new AutoValue_AllInputsWorkflow_AllInputsWorkflowOutput(
           SdkBindingData.ofInteger(i),
           SdkBindingData.ofFloat(f),
@@ -106,8 +117,10 @@ public class AllInputsWorkflow extends SdkWorkflow<AllInputsWorkflow.AllInputsWo
           SdkBindingData.ofBoolean(b),
           SdkBindingData.ofDatetime(t),
           SdkBindingData.ofDuration(d),
-          SdkBindingData.ofCollection(l, SdkBindingData::ofString),
-          SdkBindingData.ofMap(m, SdkBindingData::ofString));
+          SdkBindingData.ofStringCollection(l),
+          SdkBindingData.ofStringMap(m),
+          SdkBindingData.ofStringCollection(emptyList),
+          SdkBindingData.ofIntegerMap(emptyMap));
     }
   }
 }

--- a/flytekit-examples/src/main/java/org/flyte/examples/BatchLookUpTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/BatchLookUpTask.java
@@ -61,8 +61,7 @@ public class BatchLookUpTask
     public abstract SdkBindingData<List<String>> values();
 
     public static Output create(List<String> values) {
-      return new AutoValue_BatchLookUpTask_Output(
-          SdkBindingData.ofCollection(values, SdkBindingData::ofString));
+      return new AutoValue_BatchLookUpTask_Output(SdkBindingData.ofStringCollection(values));
     }
   }
 }

--- a/flytekit-examples/src/main/java/org/flyte/examples/PhoneBookWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/PhoneBookWorkflow.java
@@ -51,7 +51,7 @@ public class PhoneBookWorkflow extends SdkWorkflow<PhoneBookWorkflow.Output> {
      */
     public static PhoneBookWorkflow.Output create(List<String> phoneNumbers) {
       return new AutoValue_PhoneBookWorkflow_Output(
-          SdkBindingData.ofCollection(phoneNumbers, SdkBindingData::ofString));
+          SdkBindingData.ofStringCollection(phoneNumbers));
     }
   }
 
@@ -63,8 +63,7 @@ public class PhoneBookWorkflow extends SdkWorkflow<PhoneBookWorkflow.Output> {
   public void expand(SdkWorkflowBuilder builder) {
     SdkBindingData<Map<String, String>> phoneBook = SdkBindingData.ofStringMap(PHONE_BOOK);
 
-    SdkBindingData<List<String>> searchKeys =
-        SdkBindingData.ofCollection(NAMES, SdkBindingData::ofString);
+    SdkBindingData<List<String>> searchKeys = SdkBindingData.ofStringCollection(NAMES);
 
     SdkBindingData<List<String>> phoneNumbers =
         builder

--- a/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkTypeTest.java
+++ b/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkTypeTest.java
@@ -43,7 +43,6 @@ import org.flyte.api.v1.Scalar;
 import org.flyte.api.v1.SimpleType;
 import org.flyte.api.v1.Variable;
 import org.flyte.flytekit.SdkBindingData;
-import org.flyte.flytekit.SdkType;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -78,20 +77,20 @@ public class JacksonSdkTypeTest {
         SdkBindingData.ofStringMap(m),
         SdkBindingData.ofCollection(
             ll,
-            LiteralType.ofCollectionType(LiteralTypes.STRING),
-            list -> SdkBindingData.ofStringCollection(list)),
+            LiteralType.ofCollectionType(LiteralType.ofCollectionType(LiteralTypes.STRING)),
+            SdkBindingData::ofStringCollection),
         SdkBindingData.ofCollection(
-                lm,
-                LiteralType.ofMapValueType(LiteralTypes.STRING),
-                map -> SdkBindingData.ofStringMap(map)),
+            lm,
+            LiteralType.ofCollectionType(LiteralType.ofMapValueType(LiteralTypes.STRING)),
+            SdkBindingData::ofStringMap),
         SdkBindingData.ofMap(
             ml,
-            LiteralType.ofCollectionType(LiteralTypes.STRING),
-            list -> SdkBindingData.ofStringCollection(list)),
-    SdkBindingData.ofMap(
+            LiteralType.ofMapValueType(LiteralType.ofCollectionType(LiteralTypes.STRING)),
+            SdkBindingData::ofStringCollection),
+        SdkBindingData.ofMap(
             mm,
-            LiteralType.ofMapValueType(LiteralTypes.STRING),
-            map -> SdkBindingData.ofStringMap(map)));
+            LiteralType.ofMapValueType(LiteralType.ofMapValueType(LiteralTypes.STRING)),
+            SdkBindingData::ofStringMap));
   }
 
   @Test

--- a/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkTypeTest.java
+++ b/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkTypeTest.java
@@ -43,6 +43,7 @@ import org.flyte.api.v1.Scalar;
 import org.flyte.api.v1.SimpleType;
 import org.flyte.api.v1.Variable;
 import org.flyte.flytekit.SdkBindingData;
+import org.flyte.flytekit.SdkType;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -73,14 +74,24 @@ public class JacksonSdkTypeTest {
         SdkBindingData.ofBoolean(b),
         SdkBindingData.ofDatetime(t),
         SdkBindingData.ofDuration(d),
-        SdkBindingData.ofCollection(l, SdkBindingData::ofString),
+        SdkBindingData.ofStringCollection(l),
         SdkBindingData.ofStringMap(m),
         SdkBindingData.ofCollection(
-            ll, list -> SdkBindingData.ofCollection(list, SdkBindingData::ofString)),
-        SdkBindingData.ofCollection(lm, map -> SdkBindingData.ofMap(map, SdkBindingData::ofString)),
+            ll,
+            LiteralType.ofCollectionType(LiteralTypes.STRING),
+            list -> SdkBindingData.ofStringCollection(list)),
+        SdkBindingData.ofCollection(
+                lm,
+                LiteralType.ofMapValueType(LiteralTypes.STRING),
+                map -> SdkBindingData.ofStringMap(map)),
         SdkBindingData.ofMap(
-            ml, list -> SdkBindingData.ofCollection(list, SdkBindingData::ofString)),
-        SdkBindingData.ofMap(mm, map -> SdkBindingData.ofMap(map, SdkBindingData::ofString)));
+            ml,
+            LiteralType.ofCollectionType(LiteralTypes.STRING),
+            list -> SdkBindingData.ofStringCollection(list)),
+    SdkBindingData.ofMap(
+            mm,
+            LiteralType.ofMapValueType(LiteralTypes.STRING),
+            map -> SdkBindingData.ofStringMap(map)));
   }
 
   @Test
@@ -128,7 +139,7 @@ public class JacksonSdkTypeTest {
     literalMap.put("b", literalOf(Primitive.ofBooleanValue(true)));
     literalMap.put("t", literalOf(Primitive.ofDatetime(datetime)));
     literalMap.put("d", literalOf(Primitive.ofDuration(duration)));
-    //      literalMap.put("blob", literalOf(blob));
+    // literalMap.put("blob", literalOf(blob));
     literalMap.put("l", Literal.ofCollection(List.of(literalOf(Primitive.ofStringValue("123")))));
     literalMap.put("m", Literal.ofMap(Map.of("marco", literalOf(Primitive.ofStringValue("polo")))));
     literalMap.put(

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
@@ -88,63 +88,134 @@ public abstract class SdkBindingData<T> {
   }
 
   public static <T> SdkBindingData<List<T>> ofCollection(
-      List<T> collection, Function<T, SdkBindingData<T>> function) {
+      List<T> collection, LiteralType literalType, Function<T, SdkBindingData<T>> function) {
     return SdkBindingData.ofBindingCollection(
-        collection.stream().map(function).collect(Collectors.toList()));
+        literalType, collection.stream().map(function).collect(Collectors.toList()));
+  }
+
+  private static <T> SdkBindingData<List<T>> createCollection(
+      List<T> collection, LiteralType literalType, Function<T, BindingData> bindingDataFn) {
+    return create(
+        BindingData.ofCollection(
+            collection.stream().map(bindingDataFn).collect(Collectors.toList())),
+        literalType,
+        collection);
+  }
+
+  public static SdkBindingData<List<String>> ofStringCollection(List<String> collection) {
+    return createCollection(
+        collection,
+        LiteralType.ofCollectionType(LiteralType.ofSimpleType(SimpleType.STRING)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofStringValue(value))));
+  }
+
+  public static SdkBindingData<List<Double>> ofFloatCollection(List<Double> collection) {
+    return createCollection(
+        collection,
+        LiteralType.ofCollectionType(LiteralType.ofSimpleType(SimpleType.FLOAT)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofFloatValue(value))));
+  }
+
+  public static SdkBindingData<List<Long>> ofIntegerCollection(List<Long> collection) {
+    return createCollection(
+        collection,
+        LiteralType.ofCollectionType(LiteralType.ofSimpleType(SimpleType.INTEGER)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofIntegerValue(value))));
+  }
+
+  public static SdkBindingData<List<Boolean>> ofBooleanCollection(List<Boolean> collection) {
+    return createCollection(
+        collection,
+        LiteralType.ofCollectionType(LiteralType.ofSimpleType(SimpleType.BOOLEAN)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofBooleanValue(value))));
+  }
+
+  public static SdkBindingData<List<Duration>> ofDurationCollection(List<Duration> collection) {
+    return createCollection(
+        collection,
+        LiteralType.ofCollectionType(LiteralType.ofSimpleType(SimpleType.BOOLEAN)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofDuration(value))));
+  }
+
+  public static SdkBindingData<List<Instant>> ofDatetimeCollection(List<Instant> collection) {
+    return createCollection(
+        collection,
+        LiteralType.ofCollectionType(LiteralType.ofSimpleType(SimpleType.DATETIME)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofDatetime(value))));
   }
 
   public static <T> SdkBindingData<Map<String, T>> ofMap(
-      Map<String, T> map, Function<T, SdkBindingData<T>> bindingFunction) {
+      Map<String, T> map, LiteralType literalType, Function<T, SdkBindingData<T>> bindingFunction) {
     return SdkBindingData.ofBindingMap(
+        literalType,
         map.entrySet().stream()
             .map(e -> Map.entry(e.getKey(), bindingFunction.apply(e.getValue())))
             .collect(toMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
-  public static SdkBindingData<Map<String, Double>> ofFloatMap(Map<String, Double> map) {
-    return ofMap(map, SdkBindingData::ofFloat);
-  }
-
-  public static SdkBindingData<Map<String, Long>> ofIntegerMap(Map<String, Long> map) {
-    return ofMap(map, SdkBindingData::ofInteger);
+  private static <T> SdkBindingData<Map<String, T>> createMap(
+      Map<String, T> map, LiteralType literalType, Function<T, BindingData> bindingDataFn) {
+    return create(
+        BindingData.ofMap(
+            map.entrySet().stream()
+                .map(entry -> Map.entry(entry.getKey(), bindingDataFn.apply(entry.getValue())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))),
+        literalType,
+        map);
   }
 
   public static SdkBindingData<Map<String, String>> ofStringMap(Map<String, String> map) {
-    return ofMap(map, SdkBindingData::ofString);
+    return createMap(
+        map,
+        LiteralType.ofMapValueType(LiteralType.ofSimpleType(SimpleType.STRING)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofStringValue(value))));
+  }
+
+  public static SdkBindingData<Map<String, Double>> ofFloatMap(Map<String, Double> map) {
+    return createMap(
+        map,
+        LiteralType.ofMapValueType(LiteralType.ofSimpleType(SimpleType.FLOAT)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofFloatValue(value))));
+  }
+
+  public static SdkBindingData<Map<String, Long>> ofIntegerMap(Map<String, Long> map) {
+    return createMap(
+        map,
+        LiteralType.ofMapValueType(LiteralType.ofSimpleType(SimpleType.INTEGER)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofIntegerValue(value))));
   }
 
   public static SdkBindingData<Map<String, Boolean>> ofBooleanMap(Map<String, Boolean> map) {
-    return ofMap(map, SdkBindingData::ofBoolean);
+    return createMap(
+        map,
+        LiteralType.ofMapValueType(LiteralType.ofSimpleType(SimpleType.BOOLEAN)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofBooleanValue(value))));
   }
 
   public static SdkBindingData<Map<String, Duration>> ofDurationMap(Map<String, Duration> map) {
-    return ofMap(map, SdkBindingData::ofDuration);
+    return createMap(
+        map,
+        LiteralType.ofMapValueType(LiteralType.ofSimpleType(SimpleType.DURATION)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofDuration(value))));
   }
 
   public static SdkBindingData<Map<String, Instant>> ofDatetimeMap(Map<String, Instant> map) {
-    return ofMap(map, SdkBindingData::ofDatetime);
+    return createMap(
+        map,
+        LiteralType.ofMapValueType(LiteralType.ofSimpleType(SimpleType.DATETIME)),
+        (value) -> BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofDatetime(value))));
   }
 
-  public static <T> SdkBindingData<List<T>> ofBindingCollection(List<SdkBindingData<T>> elements) {
-    // TODO we can fix that by introducing "top type" into type system and
-    // implementing type casting in SDK, for now, we fail
-
-    if (elements.isEmpty()) {
-      throw new IllegalArgumentException(
-          "Can't create binding for an empty list without knowing the type, "
-              + "to create an empty map use `of<type>Collection` instead");
-    }
-
+  public static <T> SdkBindingData<List<T>> ofBindingCollection(
+      LiteralType literalType, List<SdkBindingData<T>> elements) {
     List<BindingData> bindings = elements.stream().map(SdkBindingData::idl).collect(toList());
     BindingData bindingData = BindingData.ofCollection(bindings);
 
-    LiteralType elementType = elements.get(0).type();
-    LiteralType collectionType = LiteralType.ofCollectionType(elementType);
     boolean hasPromise = bindings.stream().anyMatch(SdkBindingData::isAPromise);
     List<T> unwrappedElements =
         hasPromise ? null : elements.stream().map(SdkBindingData::get).collect(toList());
 
-    return SdkBindingData.create(bindingData, collectionType, unwrappedElements);
+    return SdkBindingData.create(bindingData, literalType, unwrappedElements);
   }
 
   private static boolean isAPromise(BindingData bindingData) {
@@ -162,15 +233,7 @@ public abstract class SdkBindingData<T> {
   }
 
   public static <T> SdkBindingData<Map<String, T>> ofBindingMap(
-      Map<String, SdkBindingData<T>> valueMap) {
-    // TODO we can fix that by introducing "top type" into type system and
-    // implementing type casting in SDK, for now, we fail
-
-    if (valueMap.isEmpty()) {
-      throw new IllegalArgumentException(
-          "Can't create binding for an empty map without knowing the type, "
-              + "to create an empty map use `of<type>Map` instead");
-    }
+      LiteralType literalType, Map<String, SdkBindingData<T>> valueMap) {
 
     Map<String, BindingData> bindings =
         valueMap.entrySet().stream()
@@ -178,8 +241,6 @@ public abstract class SdkBindingData<T> {
             .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
     BindingData bindingData = BindingData.ofMap(bindings);
 
-    LiteralType elementType = valueMap.values().iterator().next().type();
-    LiteralType mapType = LiteralType.ofMapValueType(elementType);
     boolean hasPromise = bindings.values().stream().anyMatch(SdkBindingData::isAPromise);
     Map<String, T> unwrappedElements =
         hasPromise
@@ -188,7 +249,7 @@ public abstract class SdkBindingData<T> {
                 .map(e -> Map.entry(e.getKey(), e.getValue().get()))
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-    return SdkBindingData.create(bindingData, mapType, unwrappedElements);
+    return SdkBindingData.create(bindingData, literalType, unwrappedElements);
   }
 
   public static SdkBindingData<SdkStruct> ofStruct(SdkStruct value) {

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkBindingDataTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkBindingDataTest.java
@@ -16,14 +16,16 @@
  */
 package org.flyte.flytekit;
 
+import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +49,9 @@ public class SdkBindingDataTest {
             BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofIntegerValue(42L))),
             BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofIntegerValue(1337L))));
 
-    SdkBindingData<List<Long>> output = SdkBindingData.ofBindingCollection(input);
+    SdkBindingData<List<Long>> output =
+        SdkBindingData.ofBindingCollection(
+            LiteralType.ofCollectionType(LiteralType.ofSimpleType(SimpleType.INTEGER)), input);
 
     assertThat(
         output,
@@ -60,28 +64,133 @@ public class SdkBindingDataTest {
 
   @Test
   public void testOfBindingCollection_empty() {
-    IllegalArgumentException e =
-        assertThrows(
-            IllegalArgumentException.class, () -> SdkBindingData.ofBindingCollection(emptyList()));
+    List<BindingData> expectedValue = emptyList();
+    SdkBindingData<List<Long>> expected =
+        SdkBindingData.create(
+            BindingData.ofCollection(expectedValue),
+            LiteralType.ofCollectionType(LiteralTypes.INTEGER),
+            emptyList());
+    SdkBindingData<List<Long>> output =
+        SdkBindingData.ofBindingCollection(
+            LiteralType.ofCollectionType(LiteralType.ofSimpleType(SimpleType.INTEGER)),
+            emptyList());
+    assertThat(output, equalTo(expected));
+  }
 
-    assertThat(
-        e.getMessage(),
-        equalTo(
-            "Can't create binding for an empty list without knowing the type, "
-                + "to create an empty map use `of<type>Collection` instead"));
+  @Test
+  public void testOfStringCollection() {
+    List<SdkBindingData<String>> input =
+        List.of(SdkBindingData.ofString("1"), SdkBindingData.ofString("2"));
+
+    List<String> expectedValue = List.of("1", "2");
+
+    SdkBindingData<List<String>> expected =
+        SdkBindingData.ofBindingCollection(
+            LiteralType.ofCollectionType(LiteralTypes.STRING), input);
+
+    SdkBindingData<List<String>> output = SdkBindingData.ofStringCollection(expectedValue);
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfFloatCollection() {
+    List<SdkBindingData<Double>> input =
+        List.of(SdkBindingData.ofFloat(1.1), SdkBindingData.ofFloat(1.2));
+
+    List<Double> expectedValue = List.of(1.1, 1.2);
+
+    SdkBindingData<List<Double>> expected =
+        SdkBindingData.ofBindingCollection(LiteralType.ofCollectionType(LiteralTypes.FLOAT), input);
+
+    SdkBindingData<List<Double>> output = SdkBindingData.ofFloatCollection(expectedValue);
+
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfIntegerCollection() {
+    List<SdkBindingData<Long>> input =
+        List.of(SdkBindingData.ofInteger(1L), SdkBindingData.ofInteger(2L));
+
+    List<Long> expectedValue = List.of(1L, 2L);
+
+    SdkBindingData<List<Long>> expected =
+        SdkBindingData.ofBindingCollection(
+            LiteralType.ofCollectionType(LiteralTypes.INTEGER), input);
+
+    SdkBindingData<List<Long>> output = SdkBindingData.ofIntegerCollection(expectedValue);
+
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfBooleanCollection() {
+    List<SdkBindingData<Boolean>> input =
+        List.of(SdkBindingData.ofBoolean(true), SdkBindingData.ofBoolean(false));
+
+    List<Boolean> expectedValue = List.of(true, false);
+
+    SdkBindingData<List<Boolean>> expected =
+        SdkBindingData.ofBindingCollection(
+            LiteralType.ofCollectionType(LiteralTypes.BOOLEAN), input);
+
+    SdkBindingData<List<Boolean>> output = SdkBindingData.ofBooleanCollection(expectedValue);
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfDurationCollection() {
+    List<SdkBindingData<Duration>> input =
+        List.of(
+            SdkBindingData.ofDuration(Duration.ofDays(1)),
+            SdkBindingData.ofDuration(Duration.ofDays(2)));
+
+    List<Duration> expectedValue = List.of(Duration.ofDays(1), Duration.ofDays(2));
+
+    SdkBindingData<List<Duration>> expected =
+        SdkBindingData.ofBindingCollection(
+            LiteralType.ofCollectionType(LiteralTypes.BOOLEAN), input);
+
+    SdkBindingData<List<Duration>> output = SdkBindingData.ofDurationCollection(expectedValue);
+
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfDatetimeCollection() {
+    Instant first = LocalDate.of(2022, 1, 16).atStartOfDay().toInstant(UTC);
+    Instant second = LocalDate.of(2022, 1, 17).atStartOfDay().toInstant(UTC);
+
+    List<SdkBindingData<Instant>> input =
+        List.of(SdkBindingData.ofDatetime(first), SdkBindingData.ofDatetime(second));
+
+    List<Instant> expectedValue = List.of(first, second);
+
+    SdkBindingData<List<Instant>> expected =
+        SdkBindingData.ofBindingCollection(
+            LiteralType.ofCollectionType(LiteralTypes.DATETIME), input);
+
+    SdkBindingData<List<Instant>> output = SdkBindingData.ofDatetimeCollection(expectedValue);
+
+    assertThat(output, equalTo(expected));
   }
 
   @Test
   public void testOfBindingMap() {
-    Map<String, SdkBindingData<Long>> input = new HashMap<>();
-    input.put("a", SdkBindingData.ofInteger(42L));
-    input.put("b", SdkBindingData.ofInteger(1337L));
+    Map<String, SdkBindingData<Long>> input =
+        Map.of(
+            "a", SdkBindingData.ofInteger(42L),
+            "b", SdkBindingData.ofInteger(1337L));
 
-    Map<String, BindingData> expected = new HashMap<>();
-    expected.put("a", BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofIntegerValue(42L))));
-    expected.put("b", BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofIntegerValue(1337L))));
+    Map<String, BindingData> expected =
+        Map.of(
+            "a",
+            BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofIntegerValue(42L))),
+            "b",
+            BindingData.ofScalar(Scalar.ofPrimitive(Primitive.ofIntegerValue(1337L))));
 
-    SdkBindingData<Map<String, Long>> output = SdkBindingData.ofBindingMap(input);
+    SdkBindingData<Map<String, Long>> output =
+        SdkBindingData.ofBindingMap(LiteralType.ofMapValueType(LiteralTypes.INTEGER), input);
 
     assertThat(
         output,
@@ -94,14 +203,139 @@ public class SdkBindingDataTest {
 
   @Test
   public void testOfBindingMap_empty() {
-    IllegalArgumentException e =
-        assertThrows(IllegalArgumentException.class, () -> SdkBindingData.ofBindingMap(emptyMap()));
+    Map<String, BindingData> expectedValue = emptyMap();
+    SdkBindingData<Map<String, Long>> expected =
+        SdkBindingData.create(
+            BindingData.ofMap(expectedValue),
+            LiteralType.ofMapValueType(LiteralTypes.INTEGER),
+            emptyMap());
 
-    assertThat(
-        e.getMessage(),
-        equalTo(
-            "Can't create binding for an empty map without knowing the type, "
-                + "to create an empty map use `of<type>Map` instead"));
+    SdkBindingData<Map<String, Long>> output =
+        SdkBindingData.ofBindingMap(
+            LiteralType.ofMapValueType(LiteralType.ofSimpleType(SimpleType.INTEGER)), emptyMap());
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfStringMap() {
+    Map<String, SdkBindingData<String>> input =
+        Map.of(
+            "a", SdkBindingData.ofString("1"),
+            "b", SdkBindingData.ofString("2"));
+
+    Map<String, String> expectedValue =
+        Map.of(
+            "a", "1",
+            "b", "2");
+
+    SdkBindingData<Map<String, String>> expected =
+        SdkBindingData.ofBindingMap(LiteralType.ofMapValueType(LiteralTypes.STRING), input);
+
+    SdkBindingData<Map<String, String>> output = SdkBindingData.ofStringMap(expectedValue);
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfFloatMap() {
+    Map<String, SdkBindingData<Double>> input =
+        Map.of(
+            "a", SdkBindingData.ofFloat(1.1),
+            "b", SdkBindingData.ofFloat(1.2));
+
+    Map<String, Double> expectedValue =
+        Map.of(
+            "a", 1.1,
+            "b", 1.2);
+
+    SdkBindingData<Map<String, Double>> expected =
+        SdkBindingData.ofBindingMap(LiteralType.ofMapValueType(LiteralTypes.FLOAT), input);
+
+    SdkBindingData<Map<String, Double>> output = SdkBindingData.ofFloatMap(expectedValue);
+
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfIntegerMap() {
+    Map<String, SdkBindingData<Long>> input =
+        Map.of(
+            "a", SdkBindingData.ofInteger(1L),
+            "b", SdkBindingData.ofInteger(2L));
+
+    Map<String, Long> expectedValue =
+        Map.of(
+            "a", 1L,
+            "b", 2L);
+
+    SdkBindingData<Map<String, Long>> expected =
+        SdkBindingData.ofBindingMap(LiteralType.ofMapValueType(LiteralTypes.INTEGER), input);
+
+    SdkBindingData<Map<String, Long>> output = SdkBindingData.ofIntegerMap(expectedValue);
+
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfBooleanMap() {
+    Map<String, SdkBindingData<Boolean>> input =
+        Map.of(
+            "a", SdkBindingData.ofBoolean(true),
+            "b", SdkBindingData.ofBoolean(false));
+
+    Map<String, Boolean> expectedValue =
+        Map.of(
+            "a", true,
+            "b", false);
+
+    SdkBindingData<Map<String, Boolean>> expected =
+        SdkBindingData.ofBindingMap(LiteralType.ofMapValueType(LiteralTypes.BOOLEAN), input);
+
+    SdkBindingData<Map<String, Boolean>> output = SdkBindingData.ofBooleanMap(expectedValue);
+
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfDurationMap() {
+    Map<String, SdkBindingData<Duration>> input =
+        Map.of(
+            "a", SdkBindingData.ofDuration(Duration.ofDays(1)),
+            "b", SdkBindingData.ofDuration(Duration.ofDays(2)));
+
+    Map<String, Duration> expectedValue =
+        Map.of(
+            "a", Duration.ofDays(1),
+            "b", Duration.ofDays(2));
+
+    SdkBindingData<Map<String, Duration>> expected =
+        SdkBindingData.ofBindingMap(LiteralType.ofMapValueType(LiteralTypes.DURATION), input);
+
+    SdkBindingData<Map<String, Duration>> output = SdkBindingData.ofDurationMap(expectedValue);
+
+    assertThat(output, equalTo(expected));
+  }
+
+  @Test
+  public void testOfDatetimeMap() {
+    Instant first = LocalDate.of(2022, 1, 16).atStartOfDay().toInstant(UTC);
+    Instant second = LocalDate.of(2022, 1, 17).atStartOfDay().toInstant(UTC);
+
+    Map<String, SdkBindingData<Instant>> input =
+        Map.of(
+            "a", SdkBindingData.ofDatetime(first),
+            "b", SdkBindingData.ofDatetime(second));
+
+    Map<String, Instant> expectedValue =
+        Map.of(
+            "a", first,
+            "b", second);
+
+    SdkBindingData<Map<String, Instant>> expected =
+        SdkBindingData.ofBindingMap(LiteralType.ofMapValueType(LiteralTypes.DATETIME), input);
+
+    SdkBindingData<Map<String, Instant>> output = SdkBindingData.ofDatetimeMap(expectedValue);
+
+    assertThat(output, equalTo(expected));
   }
 
   @Test

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/ListTask.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/ListTask.java
@@ -41,8 +41,7 @@ public class ListTask extends SdkRunnableTask<ListTask.Input, ListTask.Output> {
     public abstract SdkBindingData<List<Long>> list();
 
     public static Input create(List<Long> list) {
-      return new AutoValue_ListTask_Input(
-          SdkBindingData.ofCollection(list, SdkBindingData::ofInteger));
+      return new AutoValue_ListTask_Input(SdkBindingData.ofIntegerCollection(list));
     }
   }
 
@@ -51,8 +50,7 @@ public class ListTask extends SdkRunnableTask<ListTask.Input, ListTask.Output> {
     public abstract SdkBindingData<List<Long>> list();
 
     public static Output create(List<Long> list) {
-      return new AutoValue_ListTask_Output(
-          SdkBindingData.ofCollection(list, SdkBindingData::ofInteger));
+      return new AutoValue_ListTask_Output(SdkBindingData.ofIntegerCollection(list));
     }
   }
 }

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/ListWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/ListWorkflow.java
@@ -18,6 +18,8 @@ package org.flyte.localengine.examples;
 
 import com.google.auto.service.AutoService;
 import java.util.List;
+import org.flyte.api.v1.LiteralType;
+import org.flyte.api.v1.SimpleType;
 import org.flyte.flytekit.SdkBindingData;
 import org.flyte.flytekit.SdkNode;
 import org.flyte.flytekit.SdkWorkflow;
@@ -40,6 +42,7 @@ public class ListWorkflow extends SdkWorkflow<ListTask.Output> {
 
     SdkBindingData<List<Long>> list =
         SdkBindingData.ofBindingCollection(
+            LiteralType.ofCollectionType(LiteralType.ofSimpleType(SimpleType.INTEGER)),
             ImmutableList.of(sum1.getOutputs().o(), sum2.getOutputs().o()));
 
     SdkNode<ListTask.Output> list1 =

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/MapWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/MapWorkflow.java
@@ -19,6 +19,8 @@ package org.flyte.localengine.examples;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
 import java.util.Map;
+import org.flyte.api.v1.LiteralType;
+import org.flyte.api.v1.SimpleType;
 import org.flyte.flytekit.SdkBindingData;
 import org.flyte.flytekit.SdkNode;
 import org.flyte.flytekit.SdkWorkflow;
@@ -37,7 +39,7 @@ public class MapWorkflow extends SdkWorkflow<MapWorkflow.Output> {
     public abstract SdkBindingData<Map<String, String>> map();
 
     public static MapWorkflow.Output create(Map<String, String> map) {
-      return new AutoValue_MapWorkflow_Output(SdkBindingData.ofMap(map, SdkBindingData::ofString));
+      return new AutoValue_MapWorkflow_Output(SdkBindingData.ofStringMap(map));
     }
   }
 
@@ -50,7 +52,9 @@ public class MapWorkflow extends SdkWorkflow<MapWorkflow.Output> {
         builder.apply("sum-2", new SumTask().withInput("a", 3).withInput("b", 4)).getOutputs().o();
 
     SdkBindingData<Map<String, Long>> map =
-        SdkBindingData.ofBindingMap(Map.of("e", sum1, "f", sum2));
+        SdkBindingData.ofBindingMap(
+            LiteralType.ofMapValueType(LiteralType.ofSimpleType(SimpleType.INTEGER)),
+            Map.of("e", sum1, "f", sum2));
 
     SdkNode<MapTask.Output> map1 = builder.apply("map-1", new MapTask().withInput("map", map));
 


### PR DESCRIPTION
# TL;DR
Add support for empty Lists and empty Maps in SdkBindingData. 
Add helper methods to create collections of most common types:
- ofStringCollection
- ofFloatCollection
- ofIntegerCollection
- ofBooleanCollection
- ofDurationCollection
- ofDatetimeCollection

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added new helpers in SdkBindingData class and modified methods ofMap and ofCollection to ask the user to pass the LiteralType in order to be able to know the underlying type of the collection/map.
