### PR TITLE
Bump errorprone and autovalue libs #patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
   <properties>
     <auto-service.version>1.0.1</auto-service.version>
-    <auto-value.version>1.10</auto-value.version>
+    <auto-value.version>1.10.1</auto-value.version>
     <common-proto.version>2.9.6</common-proto.version>
     <grpc.version>1.46.0</grpc.version>
     <!-- must be aligned with netty version -->
@@ -95,7 +95,7 @@
     <sl4j.version>1.7.36</sl4j.version>
     <spotless.version>2.21.0</spotless.version>
     <spotbugs.excludeFilterFile>spotbugs-exclude.xml</spotbugs.excludeFilterFile>
-    <error_prone.version>2.16</error_prone.version>
+    <error_prone.version>2.17.0</error_prone.version>
     <!-- Using the error-prone-javac is required when running on JDK 8 -->
     <error_prone.javac.version>9+181-r4173-1</error_prone.javac.version>
     <junit.version>5.6.2</junit.version>


### PR DESCRIPTION
# TL;DR
Bump error prone to `2.17.0` and autovalue to `1.10.1`

## Type
 - [X] Bump dependencies
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Folds in the changes added by:
* https://github.com/flyteorg/flytekit-java/pull/174
* https://github.com/flyteorg/flytekit-java/pull/160

Snyck doesn't sign its commits and also format the pom and incompatible way

## Tracking Issue
_NA_

## Follow-up issue
_NA_
