### PR TITLE
Add remote example for launch plan

### DIFF
--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/RemoteLaunchPlan.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/RemoteLaunchPlan.scala
@@ -28,8 +28,8 @@ case class RemoteLaunchPlanOutput(fib5: SdkBindingData[Long])
 
 class RemoteLaunchPlan {
 
-  /** Note that there is no SdkRemoteWorkflow You need to register a launch plan
-    * for the workflow to achieve using a remote workflow
+  /** Note that there is no SdkRemoteWorkflow. You need to register a launch
+    * plan for the workflow to achieve using a remote workflow.
     */
   def create
       : SdkRemoteLaunchPlan[RemoteLaunchPlanInput, RemoteLaunchPlanOutput] = {

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/RemoteLaunchPlan.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/RemoteLaunchPlan.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Flyte Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.examples.flytekitscala
+
+import org.flyte.flytekit.{SdkBindingData, SdkRemoteLaunchPlan}
+import org.flyte.flytekitscala.SdkScalaType
+
+case class RemoteLaunchPlanInput(
+    fib0: SdkBindingData[Long],
+    fib1: SdkBindingData[Long]
+)
+
+case class RemoteLaunchPlanOutput(fib5: SdkBindingData[Long])
+
+class RemoteLaunchPlan {
+
+  /** Note that there is no SdkRemoteWorkflow You need to register a launch plan
+    * for the workflow to achieve using a remote workflow
+    */
+  def create
+      : SdkRemoteLaunchPlan[RemoteLaunchPlanInput, RemoteLaunchPlanOutput] = {
+    SdkRemoteLaunchPlan.create(
+      /* domain= */ "development", /* project= */ "flytesnacks",
+      /* name= */ "FibonacciWorkflowLaunchPlan",
+      SdkScalaType[RemoteLaunchPlanInput],
+      SdkScalaType[RemoteLaunchPlanOutput]
+    )
+  }
+}

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/WorkflowWithRemoteLaunchPlan.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/WorkflowWithRemoteLaunchPlan.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Flyte Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.examples.flytekitscala
+
+import org.flyte.flytekitscala.{
+  SdkBindingData,
+  SdkScalaType,
+  SdkScalaWorkflow,
+  SdkScalaWorkflowBuilder
+}
+
+class WorkflowWithRemoteLaunchPlan
+    extends SdkScalaWorkflow[RemoteLaunchPlanInput, RemoteLaunchPlanOutput](
+      SdkScalaType[RemoteLaunchPlanInput],
+      SdkScalaType[RemoteLaunchPlanOutput]
+    ) {
+
+  override def expand(builder: SdkScalaWorkflowBuilder): Unit = {
+    val fib0 = SdkBindingData.ofInteger(0L)
+    val fib1 = SdkBindingData.ofInteger(1L)
+
+    val fib5 = builder
+      .apply(
+        new RemoteLaunchPlan().create,
+        RemoteLaunchPlanInput(fib0, fib1)
+      )
+      .getOutputs
+      .fib5
+    builder.output("fib5", fib5)
+  }
+}


### PR DESCRIPTION
Signed-off-by: Sonja Ericsson <sonjae@spotify.com>


# TL;DR

Add an example of how to use a remote launch plan (launch plan deployed already in a flyte project)

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
