### PR TITLE
Do not delegate class loading to parent for some classes

### DIFF
--- a/jflyte/src/test/java/org/flyte/jflyte/ChildFirstClassLoaderTest.java
+++ b/jflyte/src/test/java/org/flyte/jflyte/ChildFirstClassLoaderTest.java
@@ -19,6 +19,7 @@ package org.flyte.jflyte;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.net.URL;
@@ -71,12 +72,32 @@ class ChildFirstClassLoaderTest {
   }
 
   @Test
+  void testLoadClassFromChild() throws IOException {
+    try (URLClassLoader classLoader =
+        new ChildFirstClassLoader(new URL[] {urlVisibleToChildOnly()})) {
+      // The class file used by the test case is empty, so we expect ClassFormatError
+      assertThrows(
+          ClassFormatError.class, () -> classLoader.loadClass("org.slf4j.impl.StaticLoggerBinder"));
+    }
+  }
+
+  @Test
   void testGetResourceNotFound() throws IOException {
     try (URLClassLoader classLoader =
         new ChildFirstClassLoader(new URL[] {urlVisibleToChildOnly()})) {
       URL resource = classLoader.getResource("META-INF/services/org.flyte.jflyte.Foo");
 
       assertNull(resource);
+    }
+  }
+
+  @Test
+  void testLoadClassNotFound() throws IOException {
+    try (URLClassLoader classLoader =
+        new ChildFirstClassLoader(new URL[] {urlVisibleToBothChildAndParent()})) {
+      assertThrows(
+          ClassNotFoundException.class,
+          () -> classLoader.loadClass("org.slf4j.impl.StaticLoggerBinder"));
     }
   }
 


### PR DESCRIPTION
# TL;DR
Only load certain classes from child.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Unfortunately https://github.com/flyteorg/flytekit-java/pull/145 did not fully fix https://github.com/flyteorg/flyte/issues/3147 because it only fixed resource, not class.

This PR will skip delegating to parent for class load as well.

This is what slf4j <2.0.x does:

```java
            if (!isAndroid()) {
                staticLoggerBinderPathSet = findPossibleStaticLoggerBinderPathSet();
                reportMultipleBindingAmbiguity(staticLoggerBinderPathSet);
            }
            // the next line does the binding
            StaticLoggerBinder.getSingleton();
```
`findPossibleStaticLoggerBinderPathSet` does the resource load so even we prevent delegation to parent at that point, `StaticLoggerBinder.getSingleton()` will still delegate to parent, without this PR.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/3147

## Follow-up issue
_NA_
