### PR TITLE
Fix maven config

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,5 @@
---show-version --batch-mode --errors --fail-at-end -Dstyle.color=always
+--show-version
+--batch-mode
+--errors
+--fail-at-end
+-Dstyle.color=always


### PR DESCRIPTION
# TL;DR
Fixes maven.config

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Since maven 3.9.0 each single argument for maven.config must be put in newline.


