### PR TITLE
Support Scala `Unit` when checking "null" inputs

### DIFF
--- a/flytekit-java/pom.xml
+++ b/flytekit-java/pom.xml
@@ -29,6 +29,11 @@
   <name>Flytekit Java</name>
   <description>Classes used by developers to build Flyte's Tasks, Workflows and Launch plans.</description>
 
+  <properties>
+    <scala.version>2.13.10</scala.version>
+  </properties>
+
+
   <dependencies>
     <!-- provided -->
     <dependency>
@@ -78,5 +83,19 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-reflect</artifactId>
+      <version>${scala.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/flytekit-java/pom.xml
+++ b/flytekit-java/pom.xml
@@ -33,7 +33,6 @@
     <scala.version>2.13.10</scala.version>
   </properties>
 
-
   <dependencies>
     <!-- provided -->
     <dependency>

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkTransform.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkTransform.java
@@ -124,15 +124,17 @@ public abstract class SdkTransform<InputT, OutputT> {
       throw new IllegalArgumentException(
           "Null supplied as input for a transform with variables: " + variableNames);
     } else if (!isNullInput && !hasProperties) {
-      throw new IllegalArgumentException("Null input expected for a transform with no variables");
+      throw new IllegalArgumentException(
+          "Null input expected for a transform with no variables, but was: " + inputs);
     }
   }
 
   // Support Unit values coming from Scala
-  private static final Set<String> NULL_CLASS_NAMES = Set.of(
-      "void", // Scala unit ()
-      "scala.runtime.BoxedUnit" // Scala unit when boxed
-  );
+  private static final Set<String> NULL_CLASS_NAMES =
+      Set.of(
+          "void", // Scala unit ()
+          "scala.runtime.BoxedUnit" // Scala unit when boxed
+          );
 
   private static boolean isNullInput(@Nullable Object input) {
     return input == null || NULL_CLASS_NAMES.contains(input.getClass().getName());

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkTransform.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkTransform.java
@@ -119,11 +119,22 @@ public abstract class SdkTransform<InputT, OutputT> {
   void checkNullOnlyVoid(@Nullable InputT inputs) {
     Set<String> variableNames = getInputType().variableNames();
     boolean hasProperties = !variableNames.isEmpty();
-    if (inputs == null && hasProperties) {
+    boolean isNullInput = isNullInput(inputs);
+    if (isNullInput && hasProperties) {
       throw new IllegalArgumentException(
           "Null supplied as input for a transform with variables: " + variableNames);
-    } else if (inputs != null && !hasProperties) {
+    } else if (!isNullInput && !hasProperties) {
       throw new IllegalArgumentException("Null input expected for a transform with no variables");
     }
+  }
+
+  // Support Unit values coming from Scala
+  private static final Set<String> NULL_CLASS_NAMES = Set.of(
+      "void", // Scala unit ()
+      "scala.runtime.BoxedUnit" // Scala unit when boxed
+  );
+
+  private static boolean isNullInput(@Nullable Object input) {
+    return input == null || NULL_CLASS_NAMES.contains(input.getClass().getName());
   }
 }

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkTransformTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkTransformTest.java
@@ -107,7 +107,9 @@ class SdkTransformTest {
                     .apply(new SdkWorkflowBuilder(), "node", List.of(), null, "not a null value"));
 
     assertThat(
-        exception.getMessage(), equalTo("Null input expected for a transform with no variables"));
+        exception.getMessage(),
+        equalTo(
+            "Null input expected for a transform with no variables, but was: not a null value"));
   }
 
   private class TransformWithInputs extends SdkTransform<TestUnaryIntegerInput, Void> {

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkTransformTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkTransformTest.java
@@ -94,10 +94,7 @@ class SdkTransformTest {
   }
 
   public static Stream<Arguments> nullValues() {
-    return Stream.of(
-        null,
-        Arguments.of(BoxedUnit.UNIT)
-    );
+    return Stream.of(null, Arguments.of(BoxedUnit.UNIT));
   }
 
   @Test


### PR DESCRIPTION
# TL;DR
Support Scala `Unit` when checking "null" inputs for transforms without variables

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

If `UnitTransform` extends is a `SdkTransform[Unit, OuputT]`  when being applied this way
```scala
builder.apply(new UnitTransform)
```
or
```scala
builder.apply(new UnitTransform, ())
```

it produces the following exception when registering the workflow

```
17:24:30.023  java.lang.IllegalArgumentException: Null input expected for a transform with no variables
17:24:30.023  	at org.flyte.flytekit.SdkTransform.checkNullOnlyVoid(SdkTransform.java:126)
17:24:30.023  	at org.flyte.flytekit.SdkTransform.apply(SdkTransform.java:52)
17:24:30.023  	at org.flyte.flytekit.SdkWorkflowBuilder.applyInternal(SdkWorkflowBuilder.java:129)
17:24:30.023  	at org.flyte.flytekit.SdkWorkflowBuilder.apply(SdkWorkflowBuilder.java:79)
17:24:30.023  	at org.flyte.flytekit.SdkWorkflowBuilder.apply(SdkWorkflowBuilder.java:102)
17:24:30.023  	at org.flyte.flytekitscala.SdkScalaWorkflowBuilder.apply(SdkScalaWorkflow.scala:149)
17:24:30.023  	at org.flyte.flytekitscala.SdkScalaWorkflow.expand(SdkScalaWorkflow.scala:52)
17:24:30.023  	at org.flyte.flytekit.SdkWorkflow.expand(SdkWorkflow.java:77)
17:24:30.023  	at org.flyte.flytekit.SdkWorkflowTemplateRegistrar.load(SdkWorkflowTemplateRegistrar.java:86)
17:24:30.023  	at org.flyte.flytekit.SdkWorkflowTemplateRegistrar.load(SdkWorkflowTemplateRegistrar.java:64)
17:24:30.023  	at org.flyte.api.v1.Registrar.load(Registrar.java:24)
17:24:30.023  	at org.flyte.jflyte.Registrars.loadAll(Registrars.java:45)
17:24:30.023  	at org.flyte.jflyte.ProjectClosure.lambda$load$9(ProjectClosure.java:222)
17:24:30.023  	at org.flyte.jflyte.ClassLoaders.withClassLoader(ClassLoaders.java:99)
17:24:30.023  	at org.flyte.jflyte.ProjectClosure.load(ProjectClosure.java:221)
17:24:30.023  	at org.flyte.jflyte.ProjectClosure.loadAndStage(ProjectClosure.java:160)
17:24:30.023  	at org.flyte.jflyte.RegisterWorkflows.call(RegisterWorkflows.java:92)
17:24:30.023  	at org.flyte.jflyte.RegisterWorkflows.call(RegisterWorkflows.java:32)
17:24:30.023  	at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
17:24:30.023  	at picocli.CommandLine.access$1500(CommandLine.java:148)
17:24:30.023  	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
17:24:30.023  	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
```

## Tracking Issue
_NA_

## Follow-up issue
_NA_
