### PR TITLE
Add registerLaunchPlan with action to SimpleSdkLaunchPlanRegistry

### DIFF
--- a/flytekit-java/src/main/java/org/flyte/flytekit/SimpleSdkLaunchPlanRegistry.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SimpleSdkLaunchPlanRegistry.java
@@ -19,6 +19,8 @@ package org.flyte.flytekit;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Base implementation of {@link SdkLaunchPlanRegistry} with handy methods to register {@link
@@ -64,5 +66,12 @@ public abstract class SimpleSdkLaunchPlanRegistry implements SdkLaunchPlanRegist
   @Override
   public List<SdkLaunchPlan> getLaunchPlans() {
     return List.copyOf(launchPlans.values());
+  }
+
+  public void registerLaunchPlans(Function<SdkWorkflow<?, ?>, Optional<SdkLaunchPlan>> action) {
+    SdkWorkflowRegistry.loadAll().stream()
+        .map(action)
+        .flatMap(Optional::stream)
+        .forEach(this::registerLaunchPlan);
   }
 }

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SimpleSdkLaunchPlanRegistry.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SimpleSdkLaunchPlanRegistry.java
@@ -68,7 +68,7 @@ public abstract class SimpleSdkLaunchPlanRegistry implements SdkLaunchPlanRegist
     return List.copyOf(launchPlans.values());
   }
 
-  public void registerLaunchPlans(Function<SdkWorkflow<?, ?>, Optional<SdkLaunchPlan>> action) {
+  protected void registerLaunchPlans(Function<SdkWorkflow<?, ?>, Optional<SdkLaunchPlan>> action) {
     SdkWorkflowRegistry.loadAll().stream()
         .map(action)
         .flatMap(Optional::stream)

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SimpleSdkLaunchPlanRegistry.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SimpleSdkLaunchPlanRegistry.java
@@ -19,7 +19,6 @@ package org.flyte.flytekit;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -68,10 +67,24 @@ public abstract class SimpleSdkLaunchPlanRegistry implements SdkLaunchPlanRegist
     return List.copyOf(launchPlans.values());
   }
 
-  protected void registerLaunchPlans(Function<SdkWorkflow<?, ?>, Optional<SdkLaunchPlan>> action) {
-    SdkWorkflowRegistry.loadAll().stream()
-        .map(action)
-        .flatMap(Optional::stream)
+  /**
+   * Register launch plans for discovered workflows using a {@link SdkWorkflow} to {@link
+   * SdkLaunchPlan} function.
+   *
+   * @param toLpFunction function to convert descoverd workflows to launch plans.
+   */
+  protected void registerLaunchPlans(
+      Function<SdkWorkflow<?, ?>, List<SdkLaunchPlan>> toLpFunction) {
+    List<SdkWorkflow<?, ?>> workflows = SdkWorkflowRegistry.loadAll();
+    registerLaunchPlans(workflows, toLpFunction);
+  }
+
+  void registerLaunchPlans(
+      List<SdkWorkflow<?, ?>> loadedWorkflows,
+      Function<SdkWorkflow<?, ?>, List<SdkLaunchPlan>> toLpFunction) {
+    loadedWorkflows.stream()
+        .map(toLpFunction)
+        .flatMap(List::stream)
         .forEach(this::registerLaunchPlan);
   }
 }

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SimpleSdkLaunchPlanTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SimpleSdkLaunchPlanTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class SimpleSdkLaunchPlanTest {
@@ -39,6 +40,13 @@ public class SimpleSdkLaunchPlanTest {
     List<SdkLaunchPlan> launchPlans = registry.getLaunchPlans();
 
     assertThat(launchPlans, equalTo(Arrays.asList(LP, LP2)));
+  }
+
+  @Test
+  void shouldRegisterLaunchPlansWithAction() {
+    TestSimpleSdkLaunchPlanRegistry registry = new TestSimpleSdkLaunchPlanRegistry();
+    registry.registerLaunchPlans(sdkWorkflow -> Optional.of(SdkLaunchPlan.of(sdkWorkflow)));
+    assertThat(registry.getLaunchPlans(), equalTo(Arrays.asList(LP, LP2)));
   }
 
   public static class TestSimpleSdkLaunchPlanRegistry extends SimpleSdkLaunchPlanRegistry {

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SimpleSdkLaunchPlanTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SimpleSdkLaunchPlanTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class SimpleSdkLaunchPlanTest {
@@ -42,17 +41,24 @@ public class SimpleSdkLaunchPlanTest {
     assertThat(launchPlans, equalTo(Arrays.asList(LP, LP2)));
   }
 
-  @Test
-  void shouldRegisterLaunchPlansWithAction() {
-    TestSimpleSdkLaunchPlanRegistry registry = new TestSimpleSdkLaunchPlanRegistry();
-    registry.registerLaunchPlans(sdkWorkflow -> Optional.of(SdkLaunchPlan.of(sdkWorkflow)));
-    assertThat(registry.getLaunchPlans(), equalTo(Arrays.asList(LP, LP2)));
-  }
-
   public static class TestSimpleSdkLaunchPlanRegistry extends SimpleSdkLaunchPlanRegistry {
     public TestSimpleSdkLaunchPlanRegistry() {
       registerLaunchPlan(LP);
       registerLaunchPlan(LP2);
+    }
+  }
+
+  @Test
+  void shouldRegisterLaunchPlansWithToLaunchPlanFucntion() {
+    TestSimpleSdkLaunchPlanRegistryWithLpFunction registry =
+        new TestSimpleSdkLaunchPlanRegistryWithLpFunction();
+    assertThat(registry.getLaunchPlans(), equalTo(Arrays.asList(LP, LP2)));
+  }
+
+  public static class TestSimpleSdkLaunchPlanRegistryWithLpFunction
+      extends SimpleSdkLaunchPlanRegistry {
+    public TestSimpleSdkLaunchPlanRegistryWithLpFunction() {
+      registerLaunchPlans(List.of(WORKFLOW), __ -> List.of(LP, LP2));
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
   <properties>
     <auto-service.version>1.0.1</auto-service.version>
     <auto-value.version>1.10.1</auto-value.version>
-    <common-proto.version>2.14.0</common-proto.version>
+    <common-proto.version>2.14.1</common-proto.version>
     <grpc.version>1.46.0</grpc.version>
     <!-- must be aligned with netty version -->
     <!-- see: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->


### PR DESCRIPTION

# TL;DR

Added a new method in SimpleSdkLaunchPlanRegistry to allow to register launchplans by loading all and executing an action per each one of them.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

Added a new method in SimpleSdkLaunchPlanRegistry to allow to register launchplans by loading all and executing an action per each one of them.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
