### PR TITLE
Explicitly fall back to real test execution when testing

### DIFF
--- a/flytekit-testing/pom.xml
+++ b/flytekit-testing/pom.xml
@@ -39,6 +39,10 @@
       <groupId>org.flyte</groupId>
       <artifactId>flytekit-local-engine</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
 
     <!-- provided -->
     <dependency>

--- a/flytekit-testing/pom.xml
+++ b/flytekit-testing/pom.xml
@@ -39,10 +39,6 @@
       <groupId>org.flyte</groupId>
       <artifactId>flytekit-local-engine</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
 
     <!-- provided -->
     <dependency>

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableLaunchPlan.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableLaunchPlan.java
@@ -35,12 +35,14 @@ public class TestingRunnableLaunchPlan<InputT, OutputT>
       SdkType<InputT> inputType,
       SdkType<OutputT> outputType,
       Function<InputT, OutputT> runFn,
+      boolean runFnProvided,
       Map<InputT, OutputT> fixedOutputs) {
     super(
         launchPlanId,
         inputType,
         outputType,
         runFn,
+        runFnProvided,
         fixedOutputs,
         TestingRunnableLaunchPlan::new,
         "launch plan",
@@ -52,6 +54,7 @@ public class TestingRunnableLaunchPlan<InputT, OutputT>
     PartialLaunchPlanIdentifier launchPlanId =
         PartialLaunchPlanIdentifier.builder().name(name).build();
 
-    return new TestingRunnableLaunchPlan<>(launchPlanId, inputType, outputType, null, emptyMap());
+    return new TestingRunnableLaunchPlan<>(
+        launchPlanId, inputType, outputType, null, false, emptyMap());
   }
 }

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableNode.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableNode.java
@@ -25,8 +25,6 @@ import org.flyte.api.v1.Literal;
 import org.flyte.api.v1.PartialIdentifier;
 import org.flyte.api.v1.RunnableNode;
 import org.flyte.flytekit.SdkType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class TestingRunnableNode<
         IdT extends PartialIdentifier,
@@ -34,9 +32,6 @@ public abstract class TestingRunnableNode<
         OutputT,
         T extends TestingRunnableNode<IdT, InputT, OutputT, T>>
     implements RunnableNode {
-
-  private static final Logger log = LoggerFactory.getLogger(TestingRunnableNode.class);
-
   protected final IdT id;
   protected final SdkType<InputT> inputType;
   protected final SdkType<OutputT> outputType;
@@ -99,10 +94,9 @@ public abstract class TestingRunnableNode<
             "Can't find input %s for remote %s [%s] across known %s inputs, "
                 + "use %s to provide a test double",
             input, type, getName(), type, testingSuggestion);
-    log.warn(message);
 
     // Not matching inputs and there is nothing to run
-    return Map.of();
+    throw new IllegalArgumentException(message);
   }
 
   @Override

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableNode.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableNode.java
@@ -38,6 +38,7 @@ public abstract class TestingRunnableNode<
 
   // @Nullable - signal nullable field but without adding the dependency
   protected final Function<InputT, OutputT> runFn;
+  private final boolean runFnProvided;
 
   protected final Map<InputT, OutputT> fixedOutputs;
   private final Creator<IdT, InputT, OutputT, T> creatorFn;
@@ -54,6 +55,7 @@ public abstract class TestingRunnableNode<
         SdkType<InputT> inputType,
         SdkType<OutputT> outputType,
         Function<InputT, OutputT> runFn,
+        boolean runFnProvided,
         Map<InputT, OutputT> fixedOutputs);
   }
 
@@ -62,6 +64,7 @@ public abstract class TestingRunnableNode<
       SdkType<InputT> inputType,
       SdkType<OutputT> outputType,
       Function<InputT, OutputT> runFn,
+      boolean runFnProvided,
       Map<InputT, OutputT> fixedOutputs,
       Creator<IdT, InputT, OutputT, T> creatorFn,
       String type,
@@ -70,6 +73,7 @@ public abstract class TestingRunnableNode<
     this.inputType = requireNonNull(inputType, "inputType");
     this.outputType = requireNonNull(outputType, "outputType");
     this.runFn = runFn; // Nullable
+    this.runFnProvided = runFnProvided;
     this.fixedOutputs = requireNonNull(fixedOutputs, "fixedOutputs");
     this.creatorFn = requireNonNull(creatorFn, "creatorFn");
     this.type = requireNonNull(type, "type");
@@ -81,12 +85,18 @@ public abstract class TestingRunnableNode<
     InputT input = inputType.fromLiteralMap(inputs);
 
     if (fixedOutputs.size() == 0) {
-      // No mocking? Run the real stuff
+      // No mocking via input matching, either run the real thing or run the provided lambda
       if (runFn != null) {
         return outputType.toLiteralMap(runFn.apply(input));
       }
-    } else if (fixedOutputs.containsKey(input)) {
-      return outputType.toLiteralMap(fixedOutputs.get(input));
+    } else {
+      if (fixedOutputs.containsKey(input)) {
+        return outputType.toLiteralMap(fixedOutputs.get(input));
+      }
+      // Inputs not matching, run the provided lambda
+      if (runFn != null && runFnProvided) {
+        return outputType.toLiteralMap(runFn.apply(input));
+      }
     }
 
     String message =
@@ -108,10 +118,10 @@ public abstract class TestingRunnableNode<
     Map<InputT, OutputT> newFixedOutputs = new HashMap<>(fixedOutputs);
     newFixedOutputs.put(input, output);
 
-    return creatorFn.create(id, inputType, outputType, runFn, newFixedOutputs);
+    return creatorFn.create(id, inputType, outputType, runFn, runFnProvided, newFixedOutputs);
   }
 
   public T withRunFn(Function<InputT, OutputT> runFn) {
-    return creatorFn.create(id, inputType, outputType, runFn, fixedOutputs);
+    return creatorFn.create(id, inputType, outputType, runFn, true, fixedOutputs);
   }
 }

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableNode.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableNode.java
@@ -80,20 +80,17 @@ public abstract class TestingRunnableNode<
   public Map<String, Literal> run(Map<String, Literal> inputs) {
     InputT input = inputType.fromLiteralMap(inputs);
 
-    if (fixedOutputs.containsKey(input)) {
-      return outputType.toLiteralMap(fixedOutputs.get(input));
-    } else if (runFn != null) {
+    // No mocking? Run the real stuff
+    if (fixedOutputs.size() == 0) {
       return outputType.toLiteralMap(runFn.apply(input));
     }
 
-    // TODO see if we can improve this error message as input is hard to read
-    // We can improve the SdkBindingData toString method
-    String message =
-        String.format(
-            "Can't find input %s for remote %s [%s] across known %s inputs, "
-                + "use %s to provide a test double",
-            input, type, getName(), type, testingSuggestion);
-    throw new IllegalArgumentException(message);
+    if (fixedOutputs.containsKey(input)) {
+      return outputType.toLiteralMap(fixedOutputs.get(input));
+    } else {
+      // Not matching inputs
+      return Map.of();
+    }
   }
 
   @Override

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableNode.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableNode.java
@@ -25,6 +25,8 @@ import org.flyte.api.v1.Literal;
 import org.flyte.api.v1.PartialIdentifier;
 import org.flyte.api.v1.RunnableNode;
 import org.flyte.flytekit.SdkType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class TestingRunnableNode<
         IdT extends PartialIdentifier,
@@ -32,6 +34,9 @@ public abstract class TestingRunnableNode<
         OutputT,
         T extends TestingRunnableNode<IdT, InputT, OutputT, T>>
     implements RunnableNode {
+
+  private static final Logger log = LoggerFactory.getLogger(TestingRunnableNode.class);
+
   protected final IdT id;
   protected final SdkType<InputT> inputType;
   protected final SdkType<OutputT> outputType;
@@ -80,17 +85,24 @@ public abstract class TestingRunnableNode<
   public Map<String, Literal> run(Map<String, Literal> inputs) {
     InputT input = inputType.fromLiteralMap(inputs);
 
-    // No mocking? Run the real stuff
     if (fixedOutputs.size() == 0) {
-      return outputType.toLiteralMap(runFn.apply(input));
+      // No mocking? Run the real stuff
+      if (runFn != null) {
+        return outputType.toLiteralMap(runFn.apply(input));
+      }
+    } else if (fixedOutputs.containsKey(input)) {
+      return outputType.toLiteralMap(fixedOutputs.get(input));
     }
 
-    if (fixedOutputs.containsKey(input)) {
-      return outputType.toLiteralMap(fixedOutputs.get(input));
-    } else {
-      // Not matching inputs
-      return Map.of();
-    }
+    String message =
+        String.format(
+            "Can't find input %s for remote %s [%s] across known %s inputs, "
+                + "use %s to provide a test double",
+            input, type, getName(), type, testingSuggestion);
+    log.warn(message);
+
+    // Not matching inputs and there is nothing to run
+    return Map.of();
   }
 
   @Override

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableTask.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableTask.java
@@ -37,12 +37,14 @@ class TestingRunnableTask<InputT, OutputT>
       SdkType<InputT> inputType,
       SdkType<OutputT> outputType,
       Function<InputT, OutputT> runFn,
+      boolean runFnProvided,
       Map<InputT, OutputT> fixedOutputs) {
     super(
         taskId,
         inputType,
         outputType,
         runFn,
+        runFnProvided,
         fixedOutputs,
         TestingRunnableTask::new,
         "task",
@@ -54,14 +56,15 @@ class TestingRunnableTask<InputT, OutputT>
     PartialTaskIdentifier taskId = PartialTaskIdentifier.builder().name(task.getName()).build();
 
     return new TestingRunnableTask<>(
-        taskId, task.getInputType(), task.getOutputType(), task::run, emptyMap());
+        taskId, task.getInputType(), task.getOutputType(), task::run, false, emptyMap());
   }
 
   static <InputT, OutputT> TestingRunnableTask<InputT, OutputT> create(
       String name, SdkType<InputT> inputType, SdkType<OutputT> outputType) {
     PartialTaskIdentifier taskId = PartialTaskIdentifier.builder().name(name).build();
 
-    return new TestingRunnableTask<>(taskId, inputType, outputType, /* runFn= */ null, emptyMap());
+    return new TestingRunnableTask<>(
+        taskId, inputType, outputType, /* runFn= */ null, false, emptyMap());
   }
 
   @Override

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/FibonacciWorkflowTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/FibonacciWorkflowTest.java
@@ -73,6 +73,7 @@ public class FibonacciWorkflowTest {
                 new SumTask(),
                 SumInput.create(SdkBindingDataFactory.of(3L), SdkBindingDataFactory.of(5L)),
                 SumOutput.create(SdkBindingDataFactory.of(42L)))
+            .withTask(new SumTask(), new SumTask()::run)
             .execute();
 
     assertThat(result.getIntegerOutput("fib2"), equalTo(2L));

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/TestingRunnableNodeTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/TestingRunnableNodeTest.java
@@ -21,7 +21,7 @@ import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.auto.value.AutoValue;
 import java.util.Map;
@@ -73,10 +73,16 @@ class TestingRunnableNodeTest {
     Map<Input, Output> fixedOutputs = singletonMap(Input.create("7"), Output.create(7L));
     TestNode node = new TestNode(null, fixedOutputs);
 
-    Map<String, Literal> output =
-        node.run(singletonMap("in", Literals.ofString("not in fixed outputs")));
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> node.run(singletonMap("in", Literals.ofString("not in fixed outputs"))));
 
-    assertThat(output, is(Map.of()));
+    assertThat(
+        ex.getMessage(),
+        equalTo(
+            "Can't find input Input{in=SdkBindingData{type=strings, value=not in fixed outputs}} for remote test [TestTask] "
+                + "across known test inputs, use a magic wang to provide a test double"));
   }
 
   @Test
@@ -103,9 +109,16 @@ class TestingRunnableNodeTest {
   void testWithoutRunFn() {
     TestNode node = new TestNode(null, emptyMap());
 
-    Map<String, Literal> output = node.run(singletonMap("in", Literals.ofString("7")));
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> node.run(singletonMap("in", Literals.ofString("7"))));
 
-    assertThat(output, is(Map.of()));
+    assertThat(
+        ex.getMessage(),
+        equalTo(
+            "Can't find input Input{in=SdkBindingData{type=strings, value=7}} for remote test [TestTask] "
+                + "across known test inputs, use a magic wang to provide a test double"));
   }
 
   @Test

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/TestingRunnableNodeTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/TestingRunnableNodeTest.java
@@ -21,7 +21,7 @@ import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.Matchers.is;
 
 import com.google.auto.value.AutoValue;
 import java.util.Map;
@@ -73,16 +73,10 @@ class TestingRunnableNodeTest {
     Map<Input, Output> fixedOutputs = singletonMap(Input.create("7"), Output.create(7L));
     TestNode node = new TestNode(null, fixedOutputs);
 
-    IllegalArgumentException ex =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> node.run(singletonMap("in", Literals.ofString("not in fixed outputs"))));
+    Map<String, Literal> output =
+        node.run(singletonMap("in", Literals.ofString("not in fixed outputs")));
 
-    assertThat(
-        ex.getMessage(),
-        equalTo(
-            "Can't find input Input{in=SdkBindingData{type=strings, value=not in fixed outputs}} for remote test [TestTask] "
-                + "across known test inputs, use a magic wang to provide a test double"));
+    assertThat(output, is(Map.of()));
   }
 
   @Test
@@ -103,6 +97,15 @@ class TestingRunnableNodeTest {
     Map<String, Literal> output = node.run(singletonMap("in", Literals.ofString("7")));
 
     assertThat(output, hasEntry("out", Literals.ofInteger(7L)));
+  }
+
+  @Test
+  void testWithoutRunFn() {
+    TestNode node = new TestNode(null, emptyMap());
+
+    Map<String, Literal> output = node.run(singletonMap("in", Literals.ofString("7")));
+
+    assertThat(output, is(Map.of()));
   }
 
   @Test

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/TestingRunnableNodeTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/TestingRunnableNodeTest.java
@@ -86,6 +86,17 @@ class TestingRunnableNodeTest {
   }
 
   @Test
+  void testRun_notFoundRunFnProvided() {
+    Function<Input, Output> fn = in -> Output.create(Long.parseLong(in.in().get()));
+    Map<Input, Output> fixedOutputs = singletonMap(Input.create("7"), Output.create(7L));
+    TestNode node = new TestNode(fn, fixedOutputs);
+
+    Map<String, Literal> output = node.run(singletonMap("in", Literals.ofString("10")));
+
+    assertThat(output, hasEntry("out", Literals.ofInteger(10L)));
+  }
+
+  @Test
   void testWithFixedOutput() {
     TestNode node =
         new TestNode(null, emptyMap()).withFixedOutput(Input.create("7"), Output.create(7L));
@@ -137,8 +148,9 @@ class TestingRunnableNodeTest {
           JacksonSdkType.of(Input.class),
           JacksonSdkType.of(Output.class),
           runFn,
+          true,
           fixedOutputs,
-          (id, inType, outType, f, m) -> new TestNode(f, m),
+          (id, inType, outType, f, fProvided, m) -> new TestNode(f, m),
           "test",
           "a magic wang");
     }


### PR DESCRIPTION
# TL;DR

More or less make #217 complete.

Closes #214 
Closes #217 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* If a task is not mocked via input matching
  * If lambda is not null, we run the lambda (lambda being either the real thing or provided)
  * Otherwise we throw
* If a task is mocked
  * If inputs match, we return output
  * If it is mocked with a provided lambda, we run the lambda
  * Otherwise, we throw

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3522

## Follow-up issue
_NA_
