### PR TITLE
Add binding collection/map to SdkBindingDataFactory for Scala

### DIFF
--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
@@ -58,9 +58,9 @@ public abstract class SdkBindingData<T> {
   /**
    * Returns a version of this {@code SdkBindingData} with a new type.
    *
-   * @param newType the {@link SdkLiteralType} type to be casted to
+   * @param newType the {@link SdkLiteralType} type to be cast to
    * @param castFunction function to apply to the value to be converted to the new type
-   * @return the type casted version of this instance
+   * @return the type cast version of this instance
    * @param <NewT> the java or scala type for the corresponding to {@code newType}
    * @throws UnsupportedOperationException if a cast cannot be performed over this instance.
    */
@@ -196,7 +196,7 @@ public abstract class SdkBindingData<T> {
         SdkLiteralType<T> elementType, List<SdkBindingData<T>> bindingCollection) {
       checkIncompatibleTypes(elementType, bindingCollection);
       return new AutoValue_SdkBindingData_BindingCollection<>(
-          collections(elementType), bindingCollection);
+          collections(elementType), List.copyOf(bindingCollection));
     }
 
     @Override
@@ -230,7 +230,7 @@ public abstract class SdkBindingData<T> {
     private static <T> BindingMap<T> create(
         SdkLiteralType<T> valuesType, Map<String, SdkBindingData<T>> bindingMap) {
       checkIncompatibleTypes(valuesType, bindingMap.values());
-      return new AutoValue_SdkBindingData_BindingMap<>(maps(valuesType), bindingMap);
+      return new AutoValue_SdkBindingData_BindingMap<>(maps(valuesType), Map.copyOf(bindingMap));
     }
 
     @Override
@@ -258,7 +258,7 @@ public abstract class SdkBindingData<T> {
     }
   }
 
-  private static <T> void checkIncompatibleTypes(
+  protected static <T> void checkIncompatibleTypes(
       SdkLiteralType<T> elementType, Collection<SdkBindingData<T>> elements) {
     List<LiteralType> incompatibleTypes =
         elements.stream()

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingDataFactory.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingDataFactory.java
@@ -286,9 +286,9 @@ public final class SdkBindingDataFactory {
    * Creates a {@code SdkBindingData} for a flyte map given a java {@code Map<String,
    * SdkBindingData<T>>} and a {@link SdkLiteralType} for the values of the map.
    *
-   * @param valueMap collection to represent on this data.
    * @param valuesType a {@link SdkLiteralType} expressing the types for the values of the map. The
-   *     keys are always String. LiteralType.Kind#MAP_VALUE_TYPE}.
+   *     keys are always String.
+   * @param valueMap map to represent on this data.
    * @return the new {@code SdkBindingData}
    */
   public static <T> SdkBindingData<Map<String, T>> ofBindingMap(

--- a/flytekit-scala-tests/pom.xml
+++ b/flytekit-scala-tests/pom.xml
@@ -45,11 +45,6 @@
     <!-- test -->
     <dependency>
       <groupId>org.flyte</groupId>
-      <artifactId>flytekit-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.flyte</groupId>
       <artifactId>flytekit-examples</artifactId>
       <scope>test</scope>
     </dependency>
@@ -61,6 +56,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataFactoryTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataFactoryTest.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021 Flyte Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekitscala
+
+import org.flyte.flytekit.SdkBindingData
+import org.flyte.flytekitscala.SdkLiteralTypes._
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+import java.time.ZoneOffset.UTC
+import java.time.{Duration, LocalDate}
+class SdkBindingDataFactoryTest {
+  @Test
+  def testOfBindingCollection(): Unit = {
+    val collection = List(42L, 1337L)
+    val bindingCollection = collection.map(SdkBindingDataFactory.of)
+    val output =
+      SdkBindingDataFactory.ofBindingCollection(integers(), bindingCollection)
+    assertThat(output.get, equalTo(collection))
+    assertThat(output.`type`, equalTo(collections(integers())))
+  }
+
+  @Test
+  def testOfBindingCollection_empty(): Unit = {
+    val output = SdkBindingDataFactory.ofBindingCollection(integers(), List())
+    assertThat(output.get, equalTo(List[Long]()))
+    assertThat(output.`type`, equalTo(collections(integers())))
+  }
+
+  @Test
+  def testOfStringCollection(): Unit = {
+    val expectedValue = List("1", "2")
+    val output = SdkBindingDataFactory.ofStringCollection(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(collections(strings())))
+  }
+
+  @Test
+  def testOfFloatCollection(): Unit = {
+    val expectedValue = List(1.1, 1.2)
+    val output = SdkBindingDataFactory.ofFloatCollection(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(collections(floats())))
+  }
+
+  @Test
+  def testOfIntegerCollection(): Unit = {
+    val expectedValue = List(1L, 2L)
+    val output = SdkBindingDataFactory.ofIntegerCollection(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(collections(integers())))
+  }
+
+  @Test
+  def testOfBooleanCollection(): Unit = {
+    val expectedValue = List(true, false)
+    val output = SdkBindingDataFactory.ofBooleanCollection(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(collections(booleans())))
+  }
+
+  @Test
+  def testOfDurationCollection(): Unit = {
+    val expectedValue = List(Duration.ofDays(1), Duration.ofDays(2))
+    val output = SdkBindingDataFactory.ofDurationCollection(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(collections(durations())))
+  }
+
+  @Test
+  def testOfDatetimeCollection(): Unit = {
+    val first = LocalDate.of(2022, 1, 16).atStartOfDay.toInstant(UTC)
+    val second = LocalDate.of(2022, 1, 17).atStartOfDay.toInstant(UTC)
+    val expectedValue = List(first, second)
+    val output = SdkBindingDataFactory.ofDatetimeCollection(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(collections(datetimes())))
+  }
+
+  @Test
+  def testOfBindingMap(): Unit = {
+    val input = Map(
+      "a" -> SdkBindingDataFactory.of(42L),
+      "b" -> SdkBindingDataFactory.of(1337L)
+    )
+    val output = SdkBindingDataFactory.ofBindingMap(integers(), input)
+    assertThat(output.get, equalTo(Map("a" -> 42L, "b" -> 1337L)))
+    assertThat(output.`type`, equalTo(maps(integers())))
+  }
+
+  @Test
+  def testOfBindingMap_empty(): Unit = {
+    val output = SdkBindingDataFactory.ofBindingMap(
+      integers(),
+      Map[String, SdkBindingData[Long]]()
+    )
+    assertThat(output.get, equalTo(Map[String, Long]()))
+    assertThat(output.`type`, equalTo(maps(integers())))
+  }
+
+  @Test def testOfStringMap(): Unit = {
+    val expectedValue = Map("a" -> "1", "b" -> "2")
+    val output: SdkBindingData[Map[String, String]] =
+      SdkBindingDataFactory.ofStringMap(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(maps(strings())))
+  }
+
+  @Test def testOfFloatMap(): Unit = {
+    val expectedValue = Map("a" -> 1.1, "b" -> 1.2)
+    val output = SdkBindingDataFactory.ofFloatMap(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(maps(floats())))
+  }
+
+  @Test def testOfIntegerMap(): Unit = {
+    val expectedValue = Map("a" -> 1L, "b" -> 2L)
+    val output = SdkBindingDataFactory.ofIntegerMap(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(maps(integers())))
+  }
+
+  @Test def testOfBooleanMap(): Unit = {
+    val expectedValue = Map("a" -> true, "b" -> false)
+    val output = SdkBindingDataFactory.ofBooleanMap(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(maps(booleans())))
+  }
+
+  @Test def testOfDurationMap(): Unit = {
+    val expectedValue =
+      Map("a" -> Duration.ofDays(1), "b" -> Duration.ofDays(2))
+    val output = SdkBindingDataFactory.ofDurationMap(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(maps(durations())))
+  }
+
+  @Test def testOfDatetimeMap(): Unit = {
+    val first = LocalDate.of(2022, 1, 16).atStartOfDay.toInstant(UTC)
+    val second = LocalDate.of(2022, 1, 17).atStartOfDay.toInstant(UTC)
+    val expectedValue = Map("a" -> first, "b" -> second)
+    val output = SdkBindingDataFactory.ofDatetimeMap(expectedValue)
+    assertThat(output.get, equalTo(expectedValue))
+    assertThat(output.`type`, equalTo(maps(datetimes())))
+  }
+}

--- a/flytekit-scala_2.13/pom.xml
+++ b/flytekit-scala_2.13/pom.xml
@@ -45,6 +45,10 @@
     <!-- compile -->
     <dependency>
       <groupId>org.flyte</groupId>
+      <artifactId>flytekit-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flyte</groupId>
       <artifactId>flytekit-java</artifactId>
     </dependency>
     <dependency>

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Flyte Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit
+
+import org.flyte.api.v1.BindingData
+import org.flyte.flytekitscala.SdkLiteralTypes.collections
+
+import java.util.function
+import scala.collection.JavaConverters._
+
+private[flyte] class BindingCollection[T](
+    elementType: SdkLiteralType[T],
+    bindingCollection: List[SdkBindingData[T]]
+) extends SdkBindingData[List[T]] {
+  SdkBindingData.checkIncompatibleTypes(elementType, bindingCollection.asJava)
+
+  override def idl: BindingData =
+    BindingData.ofCollection(bindingCollection.map(_.idl()).asJava)
+
+  override def `type`: SdkLiteralType[List[T]] = collections(elementType)
+
+  override def get(): List[T] = bindingCollection.map(_.get())
+
+  override def as[NewT](
+      newType: SdkLiteralType[NewT],
+      castFunction: function.Function[List[T], NewT]
+  ): SdkBindingData[NewT] =
+    throw new UnsupportedOperationException(
+      "SdkBindingData of binding collection cannot be casted"
+    )
+}

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Flyte Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit
+
+import org.flyte.api.v1.BindingData
+import org.flyte.flytekitscala.SdkLiteralTypes.maps
+
+import java.util.function
+import scala.collection.JavaConverters._
+
+private[flyte] class BindingMap[T](
+    valuesType: SdkLiteralType[T],
+    bindingMap: Map[String, SdkBindingData[T]]
+) extends SdkBindingData[Map[String, T]] {
+  SdkBindingData.checkIncompatibleTypes(
+    valuesType,
+    bindingMap.values.toSeq.asJava
+  )
+
+  override def idl: BindingData =
+    BindingData.ofMap(bindingMap.mapValues(_.idl()).toMap.asJava)
+
+  override def `type`: SdkLiteralType[Map[String, T]] = maps(valuesType)
+
+  override def get(): Map[String, T] = bindingMap.mapValues(_.get()).toMap
+
+  override def as[NewT](
+      newType: SdkLiteralType[NewT],
+      castFunction: function.Function[Map[String, T], NewT]
+  ): SdkBindingData[NewT] =
+    throw new UnsupportedOperationException(
+      "SdkBindingData of binding map cannot be casted"
+    )
+
+}

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/package.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/package.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Flyte Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte
+
+/** Contains subclasses for [[SdkBindingData]]. We are forced to define this
+  * package here because [[SdkBindingData#idl()]] is package private (we don´t
+  * want to expose it to users). We cannot make it protected either as it would
+  * be good for the own object but both implementations deal with list or maps
+  * of [[SdkBindingData]] and therefore cannot call this method because it is in
+  * a different class.
+  *
+  * This is not ideal because we are splitting the flytekit package in two maven
+  * modules. This would create problems when we decide to add java 9 style
+  * modules.
+  */
+package object flytekit {}

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataFactory.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataFactory.scala
@@ -16,7 +16,12 @@
  */
 package org.flyte.flytekitscala
 
-import org.flyte.flytekit.{SdkBindingData, SdkLiteralType}
+import org.flyte.flytekit.{
+  BindingCollection,
+  BindingMap,
+  SdkBindingData,
+  SdkLiteralType
+}
 import org.flyte.flytekitscala.SdkLiteralTypes._
 
 import java.time.{Duration, Instant}
@@ -309,6 +314,43 @@ object SdkBindingDataFactory {
   ): SdkBindingData[Map[String, T]] =
     SdkBindingData.literal(maps(valuesLiteralType), map)
 
+  /** Creates a [[SdkBindingData]] for a flyte collection given a scala
+    * {{{List[SdkBindingData[T]]}}} and [[SdkLiteralType]] for types for the
+    * elements.
+    *
+    * @param elementType
+    *   a [[SdkLiteralType]] expressing the types for the elements in the
+    *   collection.
+    * @param elements
+    *   collection to represent on this data.
+    * @return
+    *   the new [[SdkBindingData]]
+    */
+  def ofBindingCollection[T](
+      elementType: SdkLiteralType[T],
+      elements: List[SdkBindingData[T]]
+  ): SdkBindingData[List[T]] = {
+    new BindingCollection(elementType, elements)
+  }
+
+  /** Creates a [[SdkBindingData]] for a flyte map given a java
+    * {{{SdkBindingData[Map[String, T]]}}} and a [[SdkLiteralType]] for the
+    * values of the map.
+    *
+    * @param valuesType
+    *   a [[SdkLiteralType]] expressing the types for the values of the map. The
+    *   keys are always String.
+    * @param valueMap
+    *   map to represent on this data.
+    * @return
+    *   the new [[SdkBindingData]]
+    */
+  def ofBindingMap[T](
+      valuesType: SdkLiteralType[T],
+      valueMap: Map[String, SdkBindingData[T]]
+  ): SdkBindingData[Map[String, T]] =
+    new BindingMap(valuesType, valueMap)
+
   private def toSdkLiteralType(
       value: Any,
       internalTypeOpt: Option[SdkLiteralType[_]] = Option.empty
@@ -368,5 +410,4 @@ object SdkBindingDataFactory {
         )
     }
   }
-
 }


### PR DESCRIPTION
# TL;DR
Add methods to `SdkBindingDataFactory` to create `SdkBindingData` from collection or maps of other `SdkBindingData`

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We were missing a way to construct `SdkBindingData` from collections (or maps) of other `SdkBindingData`´s in the scalaś `SdkBindingDataFactory`, as we have in the java one.


## Tracking Issue
_NA_

## Follow-up issue
_NA_
