### PR TITLE
Add JacksonSdkLiteralType

### DIFF
--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonSdkLiteralType.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonSdkLiteralType.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.jackson;
+
+import static java.util.Objects.requireNonNull;
+import static org.flyte.flytekit.jackson.ObjectMapperUtils.createObjectMapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import org.flyte.api.v1.BindingData;
+import org.flyte.api.v1.Literal;
+import org.flyte.api.v1.LiteralType;
+import org.flyte.api.v1.Scalar;
+import org.flyte.api.v1.SimpleType;
+import org.flyte.flytekit.SdkLiteralType;
+
+/**
+ * Implementation of {@link org.flyte.flytekit.SdkLiteralType} for {@link
+ * com.google.auto.value.AutoValue}s and other java types with Jackson bindings annotations.
+ */
+public class JacksonSdkLiteralType<T> extends SdkLiteralType<T> {
+
+  private static final ObjectMapper OBJECT_MAPPER = createObjectMapper(new SdkLiteralTypeModule());
+
+  private static final LiteralType TYPE = LiteralType.ofSimpleType(SimpleType.STRUCT);
+
+  private final Class<T> clazz;
+
+  private JacksonSdkLiteralType(Class<T> clazz) {
+    this.clazz = clazz;
+  }
+
+  /**
+   * Returns a {@link org.flyte.flytekit.SdkLiteralType} for {@code clazz}.
+   *
+   * @param clazz the java type for this {@link org.flyte.flytekit.SdkLiteralType}.
+   * @return the sdk literal type
+   * @throws IllegalArgumentException when Jackson cannot find a serializer for the supplied type.
+   *     For example, it is not an {@link com.google.auto.value.AutoValue} or Jackson cannot
+   *     discover properties or constructors.
+   */
+  public static <T> JacksonSdkLiteralType<T> of(Class<T> clazz) {
+    try {
+      // preemptively check that serializer is known to throw exceptions earlier
+      SerializerProvider serializerProvider = OBJECT_MAPPER.getSerializerProviderInstance();
+
+      JsonSerializer<Object> serializer =
+          serializerProvider.findTypedValueSerializer(clazz, true, /* property= */ null);
+
+      if (serializerProvider.isUnknownTypeSerializer(serializer)) {
+        serializerProvider.reportBadDefinition(
+            clazz,
+            String.format(
+                "No serializer found for class %s and no properties discovered to create BeanSerializer",
+                clazz.getName()));
+      }
+      return new JacksonSdkLiteralType<>(clazz);
+    } catch (JsonMappingException e) {
+      throw new IllegalArgumentException(
+          String.format("Failed to find serializer for [%s]", clazz.getName()), e);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public LiteralType getLiteralType() {
+    return TYPE;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Literal toLiteral(T value) {
+    if (value == null) {
+      return null;
+    }
+
+    var tree = OBJECT_MAPPER.valueToTree(value);
+
+    try {
+      return OBJECT_MAPPER.treeToValue(tree, Literal.class);
+    } catch (IOException e) {
+      throw new UncheckedIOException("toLiteral failed for [" + clazz.getName() + "]: " + value, e);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public T fromLiteral(Literal literal) {
+    if (literal == null) {
+      return null;
+    }
+    requireNonNull(literal.scalar(), "Literal is not a struct: " + literal);
+    var struct =
+        requireNonNull(
+            literal.scalar().generic(), "Scalar literal is not a struct: " + literal.scalar());
+
+    try {
+      var tree = OBJECT_MAPPER.valueToTree(struct);
+
+      return OBJECT_MAPPER.treeToValue(tree, clazz);
+    } catch (JsonProcessingException e) {
+      throw new UncheckedIOException(
+          "fromLiteral failed for [" + clazz.getName() + "]: " + literal, e);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public BindingData toBindingData(T value) {
+    var struct = toLiteral(value).scalar().generic();
+    return BindingData.ofScalar(Scalar.ofGeneric(struct));
+  }
+}

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonSdkLiteralType.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonSdkLiteralType.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanSerializer;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import org.flyte.api.v1.BindingData;
@@ -71,6 +72,11 @@ public class JacksonSdkLiteralType<T> extends SdkLiteralType<T> {
             clazz,
             String.format(
                 "No serializer found for class %s and no properties discovered to create BeanSerializer",
+                clazz.getName()));
+      } else if (!(serializer instanceof BeanSerializer)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Class [%s] not compatible with JacksonSdkLiteralType. Use SdkLiteralType.of instead",
                 clazz.getName()));
       }
       return new JacksonSdkLiteralType<>(clazz);

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonSdkLiteralType.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonSdkLiteralType.java
@@ -132,6 +132,9 @@ public class JacksonSdkLiteralType<T> extends SdkLiteralType<T> {
   /** {@inheritDoc} */
   @Override
   public BindingData toBindingData(T value) {
+    if (value == null) {
+      return null;
+    }
     var struct = toLiteral(value).scalar().generic();
     return BindingData.ofScalar(Scalar.ofGeneric(struct));
   }

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/ObjectMapperUtils.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/ObjectMapperUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.jackson;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import com.google.errorprone.annotations.Var;
+
+final class ObjectMapperUtils {
+
+  private ObjectMapperUtils() {
+    // Prevents instantiation
+  }
+
+  static ObjectMapper createObjectMapper(Module... modules) {
+    @Var var objectMapper = new ObjectMapper();
+    for (var module : modules) {
+      objectMapper = objectMapper.registerModule(module);
+    }
+
+    return objectMapper
+        .registerModule(new JavaTimeModule())
+        .registerModule(new ParameterNamesModule());
+  }
+}

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/SdkLiteralTypeModule.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/SdkLiteralTypeModule.java
@@ -28,7 +28,7 @@ class SdkLiteralTypeModule extends Module {
 
   @Override
   public String getModuleName() {
-    return "test";
+    return "SdkLiteralType";
   }
 
   @Override

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/SdkLiteralTypeModule.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/SdkLiteralTypeModule.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.jackson;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleDeserializers;
+import com.fasterxml.jackson.databind.module.SimpleSerializers;
+import org.flyte.api.v1.Literal;
+import org.flyte.flytekit.jackson.deserializers.LiteralStructDeserializer;
+import org.flyte.flytekit.jackson.serializers.StructSerializer;
+
+class SdkLiteralTypeModule extends Module {
+
+  @Override
+  public String getModuleName() {
+    return "test";
+  }
+
+  @Override
+  public Version version() {
+    return Version.unknownVersion();
+  }
+
+  @Override
+  public void setupModule(SetupContext context) {
+    var serializers = new SimpleSerializers();
+    serializers.addSerializer(new StructSerializer());
+    context.addSerializers(serializers);
+
+    var deserializers = new SimpleDeserializers();
+    deserializers.addDeserializer(Literal.class, new LiteralStructDeserializer());
+    context.addDeserializers(deserializers);
+
+    // append with the lowest priority to use as fallback, if builtin annotations aren't present
+    context.appendAnnotationIntrospector(new AutoValueAnnotationIntrospector());
+  }
+}

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/JsonTokenUtil.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/JsonTokenUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.jackson.deserializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+final class JsonTokenUtil {
+
+  private JsonTokenUtil() {
+    // Prevents instantiation
+  }
+
+  static void verifyToken(JsonParser p, JsonToken token) {
+    if (p.currentToken() != token) {
+      throw new IllegalStateException(
+          String.format("Unexpected token [%s], expected [%s]", p.currentToken(), token));
+    }
+  }
+}

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/LiteralStructDeserializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/LiteralStructDeserializer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.jackson.deserializers;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+import static org.flyte.flytekit.jackson.deserializers.JsonTokenUtil.verifyToken;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.flyte.api.v1.Literal;
+import org.flyte.api.v1.Scalar;
+import org.flyte.api.v1.Struct;
+import org.flyte.api.v1.Struct.Value;
+
+public class LiteralStructDeserializer extends StdDeserializer<Literal> {
+  private static final long serialVersionUID = -6835948754469626304L;
+
+  public LiteralStructDeserializer() {
+    super(Literal.class);
+  }
+
+  @Override
+  public Literal deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+
+    Struct generic = readValueAsStruct(p);
+    return Literal.ofScalar(Scalar.ofGeneric(generic));
+  }
+
+  private static Struct readValueAsStruct(JsonParser p) throws IOException {
+    verifyToken(p, JsonToken.START_OBJECT);
+    p.nextToken();
+
+    Map<String, Value> fields = new HashMap<>();
+
+    while (p.currentToken() != JsonToken.END_OBJECT) {
+      verifyToken(p, JsonToken.FIELD_NAME);
+      String fieldName = p.currentName();
+      p.nextToken();
+
+      fields.put(fieldName, readValueAsStructValue(p));
+
+      p.nextToken();
+    }
+
+    return Struct.of(unmodifiableMap(fields));
+  }
+
+  private static Struct.Value readValueAsStructValue(JsonParser p) throws IOException {
+    switch (p.currentToken()) {
+      case START_ARRAY:
+        p.nextToken();
+
+        List<Value> valuesList = new ArrayList<>();
+
+        while (p.currentToken() != JsonToken.END_ARRAY) {
+          Struct.Value value = readValueAsStructValue(p);
+          p.nextToken();
+
+          valuesList.add(value);
+        }
+
+        return Struct.Value.ofListValue(unmodifiableList(valuesList));
+
+      case START_OBJECT:
+        Struct struct = readValueAsStruct(p);
+
+        return Struct.Value.ofStructValue(struct);
+
+      case VALUE_STRING:
+        String stringValue = p.readValueAs(String.class);
+
+        return Struct.Value.ofStringValue(stringValue);
+
+      case VALUE_NUMBER_FLOAT:
+      case VALUE_NUMBER_INT:
+        Double doubleValue = p.readValueAs(Double.class);
+
+        return Struct.Value.ofNumberValue(doubleValue);
+
+      case VALUE_NULL:
+        return Struct.Value.ofNullValue();
+
+      case VALUE_FALSE:
+        return Struct.Value.ofBoolValue(false);
+
+      case VALUE_TRUE:
+        return Struct.Value.ofBoolValue(true);
+
+      case FIELD_NAME:
+      case NOT_AVAILABLE:
+      case VALUE_EMBEDDED_OBJECT:
+      case END_ARRAY:
+      case END_OBJECT:
+        throw new IllegalStateException("Unexpected token: " + p.currentToken());
+    }
+
+    throw new AssertionError("Unexpected token: " + p.currentToken());
+  }
+}

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/StructSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/StructSerializer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.jackson.serializers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+import java.util.Map;
+import org.flyte.api.v1.Struct;
+import org.flyte.api.v1.Struct.Value;
+import org.flyte.api.v1.Struct.Value.Kind;
+
+public class StructSerializer extends StdSerializer<Struct> {
+  private static final long serialVersionUID = -3155214696984949940L;
+
+  public StructSerializer() {
+    super(Struct.class);
+  }
+
+  @Override
+  public void serialize(
+      Struct struct, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeStartObject();
+    for (Map.Entry<String, Struct.Value> entry : struct.fields().entrySet()) {
+      jsonGenerator.writeFieldName(entry.getKey());
+      serializeValue(entry.getValue(), jsonGenerator, serializerProvider);
+    }
+    jsonGenerator.writeEndObject();
+  }
+
+  private void serializeValue(
+      Value value, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    Kind valueKind = value.kind();
+    switch (valueKind) {
+      case STRING_VALUE:
+        jsonGenerator.writeString(value.stringValue());
+        break;
+      case BOOL_VALUE:
+        jsonGenerator.writeBoolean(value.boolValue());
+        break;
+      case NUMBER_VALUE:
+        jsonGenerator.writeNumber(value.numberValue());
+        break;
+      case NULL_VALUE:
+        jsonGenerator.writeNull();
+        break;
+      case LIST_VALUE:
+        jsonGenerator.writeStartArray();
+        for (var subValues : value.listValue()) {
+          serializeValue(subValues, jsonGenerator, serializerProvider);
+        }
+        jsonGenerator.writeEndArray();
+        break;
+      case STRUCT_VALUE:
+        serialize(value.structValue(), jsonGenerator, serializerProvider);
+        break;
+    }
+  }
+}

--- a/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkLiteralTypeTest.java
+++ b/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkLiteralTypeTest.java
@@ -22,6 +22,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.auto.value.AutoValue;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -187,6 +189,29 @@ class JacksonSdkLiteralTypeTest {
     assertThat(
         ex.getMessage(),
         equalTo(String.format("Failed to find serializer for [%s]", type.getName())));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      classes = {
+        Long.class,
+        Double.class,
+        String.class,
+        Boolean.class,
+        Duration.class,
+        Instant.class,
+        List.class,
+        Map.class
+      })
+  void shouldThrowExceptionForTypes2(Class<?> type) {
+    var ex = assertThrows(IllegalArgumentException.class, () -> JacksonSdkLiteralType.of(type));
+
+    assertThat(
+        ex.getMessage(),
+        equalTo(
+            String.format(
+                "Class [%s] not compatible with JacksonSdkLiteralType. Use SdkLiteralType.of instead",
+                type.getName())));
   }
 
   @AutoValue

--- a/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkLiteralTypeTest.java
+++ b/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkLiteralTypeTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.jackson;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.auto.value.AutoValue;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.flyte.api.v1.BindingData;
+import org.flyte.api.v1.Literal;
+import org.flyte.api.v1.LiteralType.Kind;
+import org.flyte.api.v1.Scalar;
+import org.flyte.api.v1.SimpleType;
+import org.flyte.api.v1.Struct;
+import org.flyte.api.v1.Struct.Value;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class JacksonSdkLiteralTypeTest {
+
+  private JacksonSdkLiteralType<SomeType> type;
+
+  @BeforeEach
+  void setUp() {
+    type = JacksonSdkLiteralType.of(SomeType.class);
+  }
+
+  @Test
+  void literalTypeShouldBeStruct() {
+    var literalType = type.getLiteralType();
+
+    assertThat(literalType.getKind(), equalTo(Kind.SIMPLE_TYPE));
+    assertThat(literalType.simpleType(), equalTo(SimpleType.STRUCT));
+  }
+
+  @Test
+  void shouldConvertValuesToLiteral() {
+    var value =
+        SomeType.create(1, 2.0, "3", true, null, List.of("4", "5", "6"), EmbeddedType.create(7, 8));
+    var expected =
+        Literal.ofScalar(
+            Scalar.ofGeneric(
+                Struct.of(
+                    Map.of(
+                        "i",
+                        Value.ofNumberValue(1),
+                        "f",
+                        Value.ofNumberValue(2.0),
+                        "s",
+                        Value.ofStringValue("3"),
+                        "b",
+                        Value.ofBoolValue(true),
+                        "null_",
+                        Value.ofNullValue(),
+                        "list",
+                        Value.ofListValue(
+                            List.of(
+                                Value.ofStringValue("4"),
+                                Value.ofStringValue("5"),
+                                Value.ofStringValue("6"))),
+                        "subTest",
+                        Value.ofStructValue(
+                            Struct.of(
+                                Map.of(
+                                    "a", Value.ofNumberValue(7),
+                                    "b", Value.ofNumberValue(8))))))));
+
+    var literal = type.toLiteral(value);
+
+    assertThat(literal, equalTo(expected));
+  }
+
+  @Test
+  void shouldConvertNullValuesToNullLiteral() {
+    var literal = type.toLiteral(null);
+
+    assertThat(literal, nullValue());
+  }
+
+  @Test
+  void shouldConvertLiteralToValue() {
+    var literal =
+        Literal.ofScalar(
+            Scalar.ofGeneric(
+                Struct.of(
+                    Map.of(
+                        "i",
+                        Value.ofNumberValue(1),
+                        "f",
+                        Value.ofNumberValue(2.0),
+                        "s",
+                        Value.ofStringValue("3"),
+                        "b",
+                        Value.ofBoolValue(true),
+                        "null_",
+                        Value.ofNullValue(),
+                        "list",
+                        Value.ofListValue(
+                            List.of(
+                                Value.ofStringValue("4"),
+                                Value.ofStringValue("5"),
+                                Value.ofStringValue("6"))),
+                        "subTest",
+                        Value.ofStructValue(
+                            Struct.of(
+                                Map.of(
+                                    "a", Value.ofNumberValue(7),
+                                    "b", Value.ofNumberValue(8))))))));
+    var expected =
+        SomeType.create(1, 2.0, "3", true, null, List.of("4", "5", "6"), EmbeddedType.create(7, 8));
+
+    var value = type.fromLiteral(literal);
+
+    assertThat(value, equalTo(expected));
+  }
+
+  @Test
+  void shouldConvertNullLiteralToNullValue() {
+    var value = type.fromLiteral(null);
+
+    assertThat(value, nullValue());
+  }
+
+  @Test
+  void shouldConvertValuesToBindingData() {
+    var value =
+        SomeType.create(1, 2.0, "3", true, null, List.of("4", "5", "6"), EmbeddedType.create(7, 8));
+    var expected =
+        BindingData.ofScalar(
+            Scalar.ofGeneric(
+                Struct.of(
+                    Map.of(
+                        "i",
+                        Value.ofNumberValue(1),
+                        "f",
+                        Value.ofNumberValue(2.0),
+                        "s",
+                        Value.ofStringValue("3"),
+                        "b",
+                        Value.ofBoolValue(true),
+                        "null_",
+                        Value.ofNullValue(),
+                        "list",
+                        Value.ofListValue(
+                            List.of(
+                                Value.ofStringValue("4"),
+                                Value.ofStringValue("5"),
+                                Value.ofStringValue("6"))),
+                        "subTest",
+                        Value.ofStructValue(
+                            Struct.of(
+                                Map.of(
+                                    "a", Value.ofNumberValue(7),
+                                    "b", Value.ofNumberValue(8))))))));
+
+    var bindingData = type.toBindingData(value);
+
+    assertThat(bindingData, equalTo(expected));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {TypeWithNoProperties.class, TypeWithPrivateConstructor.class})
+  void shouldThrowExceptionForTypesWithNoJacksonSerializers(Class<?> type) {
+    var ex = assertThrows(IllegalArgumentException.class, () -> JacksonSdkLiteralType.of(type));
+
+    assertThat(
+        ex.getMessage(),
+        equalTo(String.format("Failed to find serializer for [%s]", type.getName())));
+  }
+
+  @AutoValue
+  abstract static class SomeType {
+
+    abstract long i();
+
+    abstract double f();
+
+    abstract String s();
+
+    abstract boolean b();
+
+    @Nullable
+    abstract String null_();
+
+    abstract List<String> list();
+
+    abstract EmbeddedType subTest();
+
+    public static SomeType create(
+        long i,
+        double f,
+        String s,
+        boolean b,
+        String null_,
+        List<String> list,
+        EmbeddedType subTest) {
+      return new AutoValue_JacksonSdkLiteralTypeTest_SomeType(i, f, s, b, null_, list, subTest);
+    }
+  }
+
+  @AutoValue
+  abstract static class EmbeddedType {
+    abstract long a();
+
+    abstract long b();
+
+    public static EmbeddedType create(long a, long b) {
+      return new AutoValue_JacksonSdkLiteralTypeTest_EmbeddedType(a, b);
+    }
+  }
+
+  static class TypeWithPrivateConstructor {
+    private TypeWithPrivateConstructor() {
+      // private constructor prevents Jackson from instantiating objects
+    }
+
+    int getFoo() {
+      return 0;
+    }
+  }
+
+  static class TypeWithNoProperties {}
+}


### PR DESCRIPTION
# TL;DR
Add a new implementation for SdkLiteralType: JacksonSdkLiteralType is able to take bean-like classes as literal types

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 We don't support arbitrary AutoValues as SdkLiteralTypes, but this PR fixes this for Java. Now Bean-like classes (Autovalues, JacksonBinding annotated classes, and the ones that follow the Java Bean spec) can be literal types.

These bean objects will be translated to SDK Structs.

## Tracking Issue
_NA_

## Follow-up issue
We need to support the same for Scala
