### PR TITLE
Support converters to binding collection & maps

### DIFF
--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
@@ -213,8 +213,7 @@ public abstract class SdkBindingData<T> {
     @Override
     public <NewT> SdkBindingData<NewT> as(
         SdkLiteralType<NewT> newElementType, Function<List<T>, NewT> castFunction) {
-      throw new UnsupportedOperationException(
-          "SdkBindingData of binding collections cannot be casted");
+      return Literal.create(newElementType, castFunction.apply(get()));
     }
 
     @Override
@@ -249,7 +248,7 @@ public abstract class SdkBindingData<T> {
     @Override
     public <NewT> SdkBindingData<NewT> as(
         SdkLiteralType<NewT> newType, Function<Map<String, T>, NewT> castFunction) {
-      throw new UnsupportedOperationException("SdkBindingData of binding map cannot be casted");
+      return Literal.create(newType, castFunction.apply(get()));
     }
 
     @Override

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
@@ -86,7 +86,7 @@ class SdkBindingDataConvertersTest {
   }
 
   @Test
-  def testToScalaListForBindCollectionsShouldThrowException(): Unit = {
+  def testToScalaListForBindCollectionsShouldWork(): Unit = {
     val javaLongList = ju.List.of(
       SdkBindingData.literal(JavaSLT.integers(), j.Long.valueOf(1L)),
       SdkBindingData.literal(JavaSLT.integers(), j.Long.valueOf(2L)),
@@ -95,19 +95,14 @@ class SdkBindingDataConvertersTest {
     val original =
       SdkBindingData.bindingCollection(JavaSLT.integers(), javaLongList)
 
-    val exception = assertThrows(
-      classOf[UnsupportedOperationException],
-      () => toScalaList(original)
-    )
-
     assertEquals(
-      exception.getMessage,
-      "SdkBindingData of binding collections cannot be casted"
+      ScalaSBD.of(List(1L, 2L, 3L)),
+      toScalaList(original)
     )
   }
 
   @Test
-  def testToJavaListForBindCollectionsShouldThrowException(): Unit = {
+  def testToJavaListForBindCollectionsShouldWork(): Unit = {
     val scalaLongList = List(
       SdkBindingData.literal(ScalaSLT.integers(), 1L),
       SdkBindingData.literal(ScalaSLT.integers(), 2L),
@@ -119,19 +114,14 @@ class SdkBindingDataConvertersTest {
         scalaLongList.asJava
       )
 
-    val exception = assertThrows(
-      classOf[UnsupportedOperationException],
-      () => toScalaList(original)
-    )
-
     assertEquals(
-      exception.getMessage,
-      "SdkBindingData of binding collections cannot be casted"
+      ScalaSBD.of(List(1L, 2L, 3L)),
+      toScalaList(original)
     )
   }
 
   @Test
-  def testToScalaListForBindMapsShouldThrowException(): Unit = {
+  def testToScalaListForBindMapsShouldWork(): Unit = {
     val javaLongList = ju.Map.of(
       "a",
       SdkBindingData.literal(JavaSLT.integers(), j.Long.valueOf(1L)),
@@ -143,19 +133,15 @@ class SdkBindingDataConvertersTest {
     val original =
       SdkBindingData.bindingMap(JavaSLT.integers(), javaLongList)
 
-    val exception = assertThrows(
-      classOf[UnsupportedOperationException],
-      () => toScalaMap(original)
-    )
 
     assertEquals(
-      exception.getMessage,
-      "SdkBindingData of binding map cannot be casted"
+      ScalaSBD.of(Map("a" -> 1L, "b" -> 2L, "c" -> 3L)),
+      toScalaMap(original)
     )
   }
 
   @Test
-  def testToJavaListForBindMapsShouldThrowException(): Unit = {
+  def testToJavaListForBindMapsShouldWorkn(): Unit = {
     val scalaLongList = Map(
       "a" -> SdkBindingData.literal(ScalaSLT.integers(), 1L),
       "b" -> SdkBindingData.literal(ScalaSLT.integers(), 2L),
@@ -164,14 +150,9 @@ class SdkBindingDataConvertersTest {
     val original =
       SdkBindingData.bindingMap(ScalaSLT.integers(), scalaLongList.asJava)
 
-    val exception = assertThrows(
-      classOf[UnsupportedOperationException],
-      () => toScalaMap(original)
-    )
-
     assertEquals(
-      exception.getMessage,
-      "SdkBindingData of binding map cannot be casted"
+      ScalaSBD.of(Map("a" -> 1L, "b" -> 2L, "c" -> 3L)),
+      toScalaMap(original)
     )
   }
 }

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
@@ -187,7 +187,7 @@ class SdkBindingDataConvertersTest {
   }
 
   @Test
-  def testToJavaListForBindMapsShouldWorkn(): Unit = {
+  def testToJavaListForBindMapsShouldWork(): Unit = {
     val scalaLongList = Map(
       "a" -> SdkBindingData.literal(ScalaSLT.integers(), 1L),
       "b" -> SdkBindingData.literal(ScalaSLT.integers(), 2L),

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
@@ -86,6 +86,53 @@ class SdkBindingDataConvertersTest {
   }
 
   @Test
+  def testToScalaListForComplexBindCollectionsShouldWork(): Unit = {
+    val javaLongList = ju.List.of(
+      SdkBindingData.literal(
+        JavaSLT.collections(JavaSLT.maps(JavaSLT.integers())),
+        ju.List.of(
+          ju.Map.of("a", j.Long.valueOf(1L)),
+          ju.Map.of("b", j.Long.valueOf(2L)),
+          ju.Map.of("c", j.Long.valueOf(3L))
+        )
+      ),
+      SdkBindingData.literal(
+        JavaSLT.collections(JavaSLT.maps(JavaSLT.integers())),
+        ju.List.of(
+          ju.Map.of("a", j.Long.valueOf(1L)),
+          ju.Map.of("b", j.Long.valueOf(2L)),
+          ju.Map.of("c", j.Long.valueOf(3L))
+        )
+      ),
+      SdkBindingData.literal(
+        JavaSLT.collections(JavaSLT.maps(JavaSLT.integers())),
+        ju.List.of(
+          ju.Map.of("a", j.Long.valueOf(1L)),
+          ju.Map.of("b", j.Long.valueOf(2L)),
+          ju.Map.of("c", j.Long.valueOf(3L))
+        )
+      )
+    )
+
+    val original =
+      SdkBindingData.bindingCollection(
+        JavaSLT.collections(JavaSLT.maps(JavaSLT.integers())),
+        javaLongList
+      )
+
+    assertEquals(
+      ScalaSBD.of(
+        List(
+          List(Map("a" -> 1L), Map("b" -> 2L), Map("c" -> 3L)),
+          List(Map("a" -> 1L), Map("b" -> 2L), Map("c" -> 3L)),
+          List(Map("a" -> 1L), Map("b" -> 2L), Map("c" -> 3L))
+        )
+      ),
+      toScalaList(original)
+    )
+  }
+
+  @Test
   def testToScalaListForBindCollectionsShouldWork(): Unit = {
     val javaLongList = ju.List.of(
       SdkBindingData.literal(JavaSLT.integers(), j.Long.valueOf(1L)),
@@ -132,7 +179,6 @@ class SdkBindingDataConvertersTest {
     )
     val original =
       SdkBindingData.bindingMap(JavaSLT.integers(), javaLongList)
-
 
     assertEquals(
       ScalaSBD.of(Map("a" -> 1L, "b" -> 2L, "c" -> 3L)),


### PR DESCRIPTION
# TL;DR
_Please replace this text with a description of what this PR accomplishes._
Add support on the Java<->Scala converters to convert SdkBindingData created using BindingMap and BindingCollections.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
