### PR TITLE
Support converters to binding collection & maps (toJava)

### DIFF
--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
@@ -126,7 +126,7 @@ public abstract class SdkBindingData<T> {
   abstract static class Literal<T> extends SdkBindingData<T> {
     abstract T value();
 
-    private static <T> Literal<T> create(SdkLiteralType<T> type, T value) {
+    static <T> Literal<T> create(SdkLiteralType<T> type, T value) {
       return new AutoValue_SdkBindingData_Literal<>(type, value);
     }
 

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
@@ -126,7 +126,7 @@ public abstract class SdkBindingData<T> {
   abstract static class Literal<T> extends SdkBindingData<T> {
     abstract T value();
 
-    static <T> Literal<T> create(SdkLiteralType<T> type, T value) {
+    private static <T> Literal<T> create(SdkLiteralType<T> type, T value) {
       return new AutoValue_SdkBindingData_Literal<>(type, value);
     }
 

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
@@ -171,9 +171,21 @@ class SdkBindingDataConvertersTest {
       JavaSBD.of(
         JavaSLT.collections(JavaSLT.maps(JavaSLT.integers())),
         ju.List.of(
-          ju.List.of(ju.Map.of("a" , j.Long.valueOf(1L)), ju.Map.of("b" , j.Long.valueOf(2L)), ju.Map.of("c" , j.Long.valueOf(3L))),
-          ju.List.of(ju.Map.of("a" , j.Long.valueOf(1L)), ju.Map.of("b" , j.Long.valueOf(2L)), ju.Map.of("c" , j.Long.valueOf(3L))),
-          ju.List.of(ju.Map.of("a" , j.Long.valueOf(1L)), ju.Map.of("b" , j.Long.valueOf(2L)), ju.Map.of("c" , j.Long.valueOf(3L)))
+          ju.List.of(
+            ju.Map.of("a", j.Long.valueOf(1L)),
+            ju.Map.of("b", j.Long.valueOf(2L)),
+            ju.Map.of("c", j.Long.valueOf(3L))
+          ),
+          ju.List.of(
+            ju.Map.of("a", j.Long.valueOf(1L)),
+            ju.Map.of("b", j.Long.valueOf(2L)),
+            ju.Map.of("c", j.Long.valueOf(3L))
+          ),
+          ju.List.of(
+            ju.Map.of("a", j.Long.valueOf(1L)),
+            ju.Map.of("b", j.Long.valueOf(2L)),
+            ju.Map.of("c", j.Long.valueOf(3L))
+          )
         )
       ),
       toJavaList(original)
@@ -203,10 +215,14 @@ class SdkBindingDataConvertersTest {
       SdkBindingData.literal(ScalaSLT.integers(), 2L),
       SdkBindingData.literal(ScalaSLT.integers(), 3L)
     )
-    val original = ScalaSBD.ofBindingCollection(ScalaSLT.integers(), scalaLongList)
+    val original =
+      ScalaSBD.ofBindingCollection(ScalaSLT.integers(), scalaLongList)
 
     assertEquals(
-      JavaSBD.of(JavaSLT.integers(), ju.List.of(j.Long.valueOf(1L), j.Long.valueOf(2L), j.Long.valueOf(3L))),
+      JavaSBD.of(
+        JavaSLT.integers(),
+        ju.List.of(j.Long.valueOf(1L), j.Long.valueOf(2L), j.Long.valueOf(3L))
+      ),
       toJavaList(original)
     )
   }
@@ -241,7 +257,17 @@ class SdkBindingDataConvertersTest {
     val original = ScalaSBD.ofBindingMap(ScalaSLT.integers(), scalaLongList)
 
     assertEquals(
-      JavaSBD.of(JavaSLT.integers(), ju.Map.of("a", j.Long.valueOf(1L), "b", j.Long.valueOf(2L), "c", j.Long.valueOf(3L))),
+      JavaSBD.of(
+        JavaSLT.integers(),
+        ju.Map.of(
+          "a",
+          j.Long.valueOf(1L),
+          "b",
+          j.Long.valueOf(2L),
+          "c",
+          j.Long.valueOf(3L)
+        )
+      ),
       toJavaMap(original)
     )
   }

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
@@ -133,6 +133,54 @@ class SdkBindingDataConvertersTest {
   }
 
   @Test
+  def testToJavaListForComplexBindCollectionsShouldWork(): Unit = {
+    val scalaLongList = List(
+      SdkBindingData.literal(
+        ScalaSLT.collections(ScalaSLT.maps(ScalaSLT.integers())),
+        List(
+          Map("a" -> 1L),
+          Map("b" -> 2L),
+          Map("c" -> 3L)
+        )
+      ),
+      SdkBindingData.literal(
+        ScalaSLT.collections(ScalaSLT.maps(ScalaSLT.integers())),
+        List(
+          Map("a" -> 1L),
+          Map("b" -> 2L),
+          Map("c" -> 3L)
+        )
+      ),
+      SdkBindingData.literal(
+        ScalaSLT.collections(ScalaSLT.maps(ScalaSLT.integers())),
+        List(
+          Map("a" -> 1L),
+          Map("b" -> 2L),
+          Map("c" -> 3L)
+        )
+      )
+    )
+
+    val original =
+      ScalaSBD.ofBindingCollection(
+        ScalaSLT.collections(ScalaSLT.maps(ScalaSLT.integers())),
+        scalaLongList
+      )
+
+    assertEquals(
+      JavaSBD.of(
+        JavaSLT.collections(JavaSLT.maps(JavaSLT.integers())),
+        ju.List.of(
+          ju.List.of(ju.Map.of("a" , j.Long.valueOf(1L)), ju.Map.of("b" , j.Long.valueOf(2L)), ju.Map.of("c" , j.Long.valueOf(3L))),
+          ju.List.of(ju.Map.of("a" , j.Long.valueOf(1L)), ju.Map.of("b" , j.Long.valueOf(2L)), ju.Map.of("c" , j.Long.valueOf(3L))),
+          ju.List.of(ju.Map.of("a" , j.Long.valueOf(1L)), ju.Map.of("b" , j.Long.valueOf(2L)), ju.Map.of("c" , j.Long.valueOf(3L)))
+        )
+      ),
+      toJavaList(original)
+    )
+  }
+
+  @Test
   def testToScalaListForBindCollectionsShouldWork(): Unit = {
     val javaLongList = ju.List.of(
       SdkBindingData.literal(JavaSLT.integers(), j.Long.valueOf(1L)),
@@ -155,15 +203,11 @@ class SdkBindingDataConvertersTest {
       SdkBindingData.literal(ScalaSLT.integers(), 2L),
       SdkBindingData.literal(ScalaSLT.integers(), 3L)
     )
-    val original =
-      SdkBindingData.bindingCollection(
-        ScalaSLT.integers(),
-        scalaLongList.asJava
-      )
+    val original = ScalaSBD.ofBindingCollection(ScalaSLT.integers(), scalaLongList)
 
     assertEquals(
-      ScalaSBD.of(List(1L, 2L, 3L)),
-      toScalaList(original)
+      JavaSBD.of(JavaSLT.integers(), ju.List.of(j.Long.valueOf(1L), j.Long.valueOf(2L), j.Long.valueOf(3L))),
+      toJavaList(original)
     )
   }
 
@@ -193,12 +237,12 @@ class SdkBindingDataConvertersTest {
       "b" -> SdkBindingData.literal(ScalaSLT.integers(), 2L),
       "c" -> SdkBindingData.literal(ScalaSLT.integers(), 3L)
     )
-    val original =
-      SdkBindingData.bindingMap(ScalaSLT.integers(), scalaLongList.asJava)
+
+    val original = ScalaSBD.ofBindingMap(ScalaSLT.integers(), scalaLongList)
 
     assertEquals(
-      ScalaSBD.of(Map("a" -> 1L, "b" -> 2L, "c" -> 3L)),
-      toScalaMap(original)
+      JavaSBD.of(JavaSLT.integers(), ju.Map.of("a", j.Long.valueOf(1L), "b", j.Long.valueOf(2L), "c", j.Long.valueOf(3L))),
+      toJavaMap(original)
     )
   }
 }

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
@@ -40,5 +40,5 @@ private[flyte] class BindingCollection[T](
       newType: SdkLiteralType[NewT],
       castFunction: function.Function[List[T], NewT]
   ): SdkBindingData[NewT] =
-    Literal.create(newType, castFunction.apply(get()))
+    SdkBindingData.literal(newType, castFunction.apply(get()))
 }

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
@@ -17,6 +17,7 @@
 package org.flyte.flytekit
 
 import org.flyte.api.v1.BindingData
+import org.flyte.flytekit.SdkBindingData.Literal
 import org.flyte.flytekitscala.SdkLiteralTypes.collections
 
 import java.util.function
@@ -39,7 +40,5 @@ private[flyte] class BindingCollection[T](
       newType: SdkLiteralType[NewT],
       castFunction: function.Function[List[T], NewT]
   ): SdkBindingData[NewT] =
-    throw new UnsupportedOperationException(
-      "SdkBindingData of binding collection cannot be casted"
-    )
+    Literal.create(newType, castFunction.apply(get()))
 }

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
@@ -17,6 +17,7 @@
 package org.flyte.flytekit
 
 import org.flyte.api.v1.BindingData
+import org.flyte.flytekit.SdkBindingData.Literal
 import org.flyte.flytekitscala.SdkLiteralTypes.maps
 
 import java.util.function
@@ -42,8 +43,6 @@ private[flyte] class BindingMap[T](
       newType: SdkLiteralType[NewT],
       castFunction: function.Function[Map[String, T], NewT]
   ): SdkBindingData[NewT] =
-    throw new UnsupportedOperationException(
-      "SdkBindingData of binding map cannot be casted"
-    )
+    Literal.create(newType, castFunction.apply(get()))
 
 }

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
@@ -43,6 +43,6 @@ private[flyte] class BindingMap[T](
       newType: SdkLiteralType[NewT],
       castFunction: function.Function[Map[String, T], NewT]
   ): SdkBindingData[NewT] =
-    Literal.create(newType, castFunction.apply(get()))
+    SdkBindingData.literal(newType, castFunction.apply(get()))
 
 }


### PR DESCRIPTION
# TL;DR
Follow-up PR of https://github.com/flyteorg/flytekit-java/pull/226 to fix the `toJava()` of bindingCollection and bindingMap

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
