### PR TITLE
Align java examples with scala ones

### DIFF
--- a/flytekit-examples/src/main/java/org/flyte/examples/SubWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/SubWorkflow.java
@@ -17,50 +17,28 @@
 package org.flyte.examples;
 
 import com.google.auto.service.AutoService;
-import com.google.auto.value.AutoValue;
 import org.flyte.flytekit.SdkBindingData;
 import org.flyte.flytekit.SdkWorkflow;
 import org.flyte.flytekit.SdkWorkflowBuilder;
-import org.flyte.flytekit.jackson.Description;
 import org.flyte.flytekit.jackson.JacksonSdkType;
 
 @AutoService(SdkWorkflow.class)
-public class SubWorkflow extends SdkWorkflow<SubWorkflow.Input, SubWorkflow.Output> {
+public class SubWorkflow extends SdkWorkflow<WelcomeWorkflow.Input, WelcomeWorkflow.Output> {
 
   public SubWorkflow() {
-    super(JacksonSdkType.of(SubWorkflow.Input.class), JacksonSdkType.of(SubWorkflow.Output.class));
+    super(
+        JacksonSdkType.of(WelcomeWorkflow.Input.class),
+        JacksonSdkType.of(WelcomeWorkflow.Output.class));
   }
 
   @Override
-  public Output expand(SdkWorkflowBuilder builder, Input input) {
-    SdkBindingData<Long> result =
+  public WelcomeWorkflow.Output expand(SdkWorkflowBuilder builder, WelcomeWorkflow.Input input) {
+    SdkBindingData<String> greeting =
         builder
-            .apply("sum", new SumTask(), SumTask.SumInput.create(input.left(), input.right()))
-            .getOutputs();
-    return Output.create(result);
-  }
+            .apply("greet", new WelcomeWorkflow(), WelcomeWorkflow.Input.create(input.name()))
+            .getOutputs()
+            .greeting();
 
-  // Used in testing to mock this workflow
-  @AutoValue
-  public abstract static class Input {
-    @Description("First operand")
-    abstract SdkBindingData<Long> left();
-
-    @Description("Second operand")
-    abstract SdkBindingData<Long> right();
-
-    public static Input create(SdkBindingData<Long> left, SdkBindingData<Long> right) {
-      return new AutoValue_SubWorkflow_Input(left, right);
-    }
-  }
-
-  @AutoValue
-  public abstract static class Output {
-    @Description("Summed results")
-    abstract SdkBindingData<Long> result();
-
-    public static Output create(SdkBindingData<Long> result) {
-      return new AutoValue_SubWorkflow_Output(result);
-    }
+    return WelcomeWorkflow.Output.create(greeting);
   }
 }

--- a/flytekit-examples/src/main/java/org/flyte/examples/SumWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/SumWorkflow.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Flyte Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.examples;
+
+import com.google.auto.service.AutoService;
+import com.google.auto.value.AutoValue;
+import org.flyte.flytekit.SdkBindingData;
+import org.flyte.flytekit.SdkWorkflow;
+import org.flyte.flytekit.SdkWorkflowBuilder;
+import org.flyte.flytekit.jackson.Description;
+import org.flyte.flytekit.jackson.JacksonSdkType;
+
+@AutoService(SdkWorkflow.class)
+public class SumWorkflow extends SdkWorkflow<SumWorkflow.Input, SumWorkflow.Output> {
+
+  public SumWorkflow() {
+    super(JacksonSdkType.of(SumWorkflow.Input.class), JacksonSdkType.of(SumWorkflow.Output.class));
+  }
+
+  @Override
+  public Output expand(SdkWorkflowBuilder builder, Input input) {
+    SdkBindingData<Long> result =
+        builder
+            .apply("sum", new SumTask(), SumTask.SumInput.create(input.left(), input.right()))
+            .getOutputs();
+    return Output.create(result);
+  }
+
+  // Used in testing to mock this workflow
+  @AutoValue
+  public abstract static class Input {
+    @Description("First operand")
+    abstract SdkBindingData<Long> left();
+
+    @Description("Second operand")
+    abstract SdkBindingData<Long> right();
+
+    public static Input create(SdkBindingData<Long> left, SdkBindingData<Long> right) {
+      return new AutoValue_SumWorkflow_Input(left, right);
+    }
+  }
+
+  @AutoValue
+  public abstract static class Output {
+    @Description("Summed results")
+    abstract SdkBindingData<Long> result();
+
+    public static Output create(SdkBindingData<Long> result) {
+      return new AutoValue_SumWorkflow_Output(result);
+    }
+  }
+}

--- a/flytekit-examples/src/main/java/org/flyte/examples/UberWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/UberWorkflow.java
@@ -24,7 +24,7 @@ import org.flyte.flytekit.SdkWorkflowBuilder;
 import org.flyte.flytekit.jackson.JacksonSdkType;
 
 @AutoService(SdkWorkflow.class)
-public class UberWorkflow extends SdkWorkflow<UberWorkflow.Input, SubWorkflow.Output> {
+public class UberWorkflow extends SdkWorkflow<UberWorkflow.Input, SumWorkflow.Output> {
 
   @AutoValue
   public abstract static class Input {
@@ -47,27 +47,27 @@ public class UberWorkflow extends SdkWorkflow<UberWorkflow.Input, SubWorkflow.Ou
   }
 
   public UberWorkflow() {
-    super(JacksonSdkType.of(UberWorkflow.Input.class), JacksonSdkType.of(SubWorkflow.Output.class));
+    super(JacksonSdkType.of(UberWorkflow.Input.class), JacksonSdkType.of(SumWorkflow.Output.class));
   }
 
   @Override
-  public SubWorkflow.Output expand(SdkWorkflowBuilder builder, Input input) {
+  public SumWorkflow.Output expand(SdkWorkflowBuilder builder, Input input) {
     SdkBindingData<Long> a = input.a();
     SdkBindingData<Long> b = input.b();
     SdkBindingData<Long> c = input.c();
     SdkBindingData<Long> d = input.d();
     SdkBindingData<Long> ab =
         builder
-            .apply("sub-1", new SubWorkflow(), SubWorkflow.Input.create(a, b))
+            .apply("sub-1", new SumWorkflow(), SumWorkflow.Input.create(a, b))
             .getOutputs()
             .result();
     SdkBindingData<Long> abc =
         builder
-            .apply("sub-2", new SubWorkflow(), SubWorkflow.Input.create(ab, c))
+            .apply("sub-2", new SumWorkflow(), SumWorkflow.Input.create(ab, c))
             .getOutputs()
             .result();
     SdkBindingData<Long> abcd =
         builder.apply("post-sum", new SumTask(), SumTask.SumInput.create(abc, d)).getOutputs();
-    return SubWorkflow.Output.create(abcd);
+    return SumWorkflow.Output.create(abcd);
   }
 }

--- a/flytekit-examples/src/main/java/org/flyte/examples/WelcomeWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/WelcomeWorkflow.java
@@ -26,7 +26,7 @@ import org.flyte.flytekit.jackson.JacksonSdkType;
 
 /** Example workflow that takes a name and outputs a welcome message. */
 @AutoService(SdkWorkflow.class)
-public class WelcomeWorkflow extends SdkWorkflow<WelcomeWorkflow.Input, AddQuestionTask.Output> {
+public class WelcomeWorkflow extends SdkWorkflow<WelcomeWorkflow.Input, WelcomeWorkflow.Output> {
 
   @AutoValue
   public abstract static class Input {
@@ -38,14 +38,23 @@ public class WelcomeWorkflow extends SdkWorkflow<WelcomeWorkflow.Input, AddQuest
     }
   }
 
+  @AutoValue
+  public abstract static class Output {
+    public abstract SdkBindingData<String> greeting();
+
+    public static Output create(SdkBindingData<String> greeting) {
+      return new AutoValue_WelcomeWorkflow_Output(greeting);
+    }
+  }
+
   public WelcomeWorkflow() {
     super(
         JacksonSdkType.of(WelcomeWorkflow.Input.class),
-        JacksonSdkType.of(AddQuestionTask.Output.class));
+        JacksonSdkType.of(WelcomeWorkflow.Output.class));
   }
 
   @Override
-  public AddQuestionTask.Output expand(SdkWorkflowBuilder builder, Input input) {
+  public WelcomeWorkflow.Output expand(SdkWorkflowBuilder builder, Input input) {
     // uses the workflow input as the task input of the GreetTask
     SdkBindingData<String> greeting =
         builder
@@ -60,6 +69,6 @@ public class WelcomeWorkflow extends SdkWorkflow<WelcomeWorkflow.Input, AddQuest
             .getOutputs()
             .greeting();
 
-    return AddQuestionTask.Output.create(greetingWithQuestion);
+    return WelcomeWorkflow.Output.create(greetingWithQuestion);
   }
 }

--- a/flytekit-examples/src/test/java/org/flyte/examples/WorkflowTest.java
+++ b/flytekit-examples/src/test/java/org/flyte/examples/WorkflowTest.java
@@ -29,14 +29,9 @@ public class WorkflowTest {
   @Test
   public void testSubWorkflow() {
     SdkTestingExecutor.Result result =
-        SdkTestingExecutor.of(new UberWorkflow())
-            .withFixedInput("a", 1)
-            .withFixedInput("b", 2)
-            .withFixedInput("c", 3)
-            .withFixedInput("d", 4)
-            .execute();
+        SdkTestingExecutor.of(new SubWorkflow()).withFixedInput("name", "foo").execute();
 
-    assertEquals(10L, result.getIntegerOutput("result"));
+    assertEquals("Welcome, foo! How are you?", result.getStringOutput("greeting"));
   }
 
   @Test
@@ -75,19 +70,19 @@ public class WorkflowTest {
             // Deliberately mock with absurd values to make sure that we are not picking the
             // SumTask implementation
             .withWorkflowOutput(
-                new SubWorkflow(),
-                JacksonSdkType.of(SubWorkflow.Input.class),
-                SubWorkflow.Input.create(
+                new SumWorkflow(),
+                JacksonSdkType.of(SumWorkflow.Input.class),
+                SumWorkflow.Input.create(
                     SdkBindingDataFactory.of(1L), SdkBindingDataFactory.of(2L)),
-                JacksonSdkType.of(SubWorkflow.Output.class),
-                SubWorkflow.Output.create(SdkBindingDataFactory.of(5L)))
+                JacksonSdkType.of(SumWorkflow.Output.class),
+                SumWorkflow.Output.create(SdkBindingDataFactory.of(5L)))
             .withWorkflowOutput(
-                new SubWorkflow(),
-                JacksonSdkType.of(SubWorkflow.Input.class),
-                SubWorkflow.Input.create(
+                new SumWorkflow(),
+                JacksonSdkType.of(SumWorkflow.Input.class),
+                SumWorkflow.Input.create(
                     SdkBindingDataFactory.of(5L), SdkBindingDataFactory.of(3L)),
-                JacksonSdkType.of(SubWorkflow.Output.class),
-                SubWorkflow.Output.create(SdkBindingDataFactory.of(10L)))
+                JacksonSdkType.of(SumWorkflow.Output.class),
+                SumWorkflow.Output.create(SdkBindingDataFactory.of(10L)))
             .withTaskOutput(
                 new SumTask(),
                 SumInput.create(SdkBindingDataFactory.of(10L), SdkBindingDataFactory.of(4L)),


### PR DESCRIPTION
# TL;DR
Align java examples with scala ones, for the subworkflow related things.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
It is a bit confusing that `SubWorkflow` in Java and Scala carries different meaning for different purpose. So we align the Java one with Scala.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
