### PR TITLE
Remove compile dependency of flytekit-api

### DIFF
--- a/flytekit-scala_2.13/pom.xml
+++ b/flytekit-scala_2.13/pom.xml
@@ -45,10 +45,6 @@
     <!-- compile -->
     <dependency>
       <groupId>org.flyte</groupId>
-      <artifactId>flytekit-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.flyte</groupId>
       <artifactId>flytekit-java</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
# TL;DR
Remove compile dependency of flytekit-api

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This should never be `compile` scope otherwise we are leaking it into user space. Fortunately with ChildFirstClassLoader nothing bad has happened. Note that this dependency is already defined as `provided` a few lines below.

This was introduced in #219 .

## Tracking Issue

Closes https://github.com/flyteorg/flyte/issues/3911

## Follow-up issue
_NA_
