### PR TITLE
Retro fix all years

### DIFF
--- a/flyteidl-protos/pom.xml
+++ b/flyteidl-protos/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2021-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-api/pom.xml
+++ b/flytekit-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Binding.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/BindingData.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/BindingData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Blob.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Blob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/BlobMetadata.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/BlobMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/BlobType.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/BlobType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/BooleanExpression.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/BooleanExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/BranchNode.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/BranchNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/ComparisonExpression.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/ComparisonExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/ConjunctionExpression.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/ConjunctionExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Container.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Container.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/ContainerError.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/ContainerError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/ContainerTask.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/ContainerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/ContainerTaskRegistrar.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/ContainerTaskRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/CronSchedule.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/CronSchedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/DynamicJobSpec.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/DynamicJobSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/DynamicWorkflowTask.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/DynamicWorkflowTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/DynamicWorkflowTaskRegistrar.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/DynamicWorkflowTaskRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Identifier.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Identifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/IfBlock.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/IfBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/IfElseBlock.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/IfElseBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/KeyValuePair.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/KeyValuePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/LaunchPlan.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/LaunchPlan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/LaunchPlanIdentifier.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/LaunchPlanIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/LaunchPlanRegistrar.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/LaunchPlanRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Literal.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Literal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/LiteralType.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/LiteralType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/NamedEntityIdentifier.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/NamedEntityIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Node.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/NodeError.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/NodeError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/NodeMetadata.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/NodeMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/OnFailurePolicy.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/OnFailurePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Operand.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Operand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/OutputReference.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/OutputReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Parameter.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/PartialIdentifier.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/PartialIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/PartialLaunchPlanIdentifier.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/PartialLaunchPlanIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/PartialTaskIdentifier.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/PartialTaskIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/PartialWorkflowIdentifier.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/PartialWorkflowIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Preconditions.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Preconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Primitive.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Primitive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Registrar.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Registrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Resources.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/RetryStrategy.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/RetryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/RunnableNode.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/RunnableNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/RunnableTask.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/RunnableTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/RunnableTaskRegistrar.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/RunnableTaskRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Scalar.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Scalar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/SchemaType.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/SchemaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/SimpleType.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/SimpleType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Struct.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Struct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Task.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Task.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/TaskIdentifier.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/TaskIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/TaskNode.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/TaskNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/TaskTemplate.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/TaskTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/TypedInterface.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/TypedInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Variable.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Variable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/WorkflowIdentifier.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/WorkflowIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/WorkflowMetadata.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/WorkflowMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/WorkflowNode.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/WorkflowNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/WorkflowTemplate.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/WorkflowTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-api/src/main/java/org/flyte/api/v1/WorkflowTemplateRegistrar.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/WorkflowTemplateRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/pom.xml
+++ b/flytekit-examples-scala/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/AddQuestionTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/AddQuestionTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/DynamicFibonacciWorkflow.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/DynamicFibonacciWorkflow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/DynamicFibonacciWorkflowTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/DynamicFibonacciWorkflowTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2022-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/FibonacciLaunchPlan.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/FibonacciLaunchPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2021 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/FibonacciWorkflow.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/FibonacciWorkflow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/GreetTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/GreetTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/HelloWorldTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/HelloWorldTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/NoInputsTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/NoInputsTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/NoInputsWorkflow.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/NoInputsWorkflow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/RemoteLaunchPlan.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/RemoteLaunchPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/RemoteSumTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/RemoteSumTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/SubWorkflow.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/SubWorkflow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/SumTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/SumTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/WelcomeWorkflow.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/WelcomeWorkflow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2021-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/WorkflowWithRemoteLaunchPlan.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/WorkflowWithRemoteLaunchPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/WorkflowWithRemoteTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/WorkflowWithRemoteTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/pom.xml
+++ b/flytekit-examples/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/AddQuestionTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/AddQuestionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/AllInputsLaunchPlan.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/AllInputsLaunchPlan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/AllInputsTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/AllInputsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/AllInputsWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/AllInputsWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/BatchLookUpTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/BatchLookUpTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/ConditionalGreetingWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/ConditionalGreetingWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/ContainerLaunchPlanRegistry.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/ContainerLaunchPlanRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/ContainerWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/ContainerWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/DynamicFibonacciWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/DynamicFibonacciWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/DynamicFibonacciWorkflowTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/DynamicFibonacciWorkflowTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/FibonacciLaunchPlan.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/FibonacciLaunchPlan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/FibonacciWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/FibonacciWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/GreetTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/GreetTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/HelloContainerTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/HelloContainerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/HelloWorldTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/HelloWorldTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/HelloWorldWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/HelloWorldWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/NodeMetadataExampleWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/NodeMetadataExampleWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/PhoneBookWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/PhoneBookWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/PrintMessageTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/PrintMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/RemoteLaunchPlanExample.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/RemoteLaunchPlanExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/SimpleStructTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/SimpleStructTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/SubWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/SubWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/SumTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/SumTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/SumWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/SumWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/UberWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/UberWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/main/java/org/flyte/examples/WelcomeWorkflow.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/WelcomeWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-examples/src/test/java/org/flyte/examples/WorkflowTest.java
+++ b/flytekit-examples/src/test/java/org/flyte/examples/WorkflowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/pom.xml
+++ b/flytekit-jackson/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/Description.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonBindingMap.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonBindingMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonLiteralMap.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonLiteralMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonSdkLiteralType.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonSdkLiteralType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonSdkType.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/JacksonSdkType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/LiteralTypes.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/LiteralTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/ObjectMapperUtils.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/ObjectMapperUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/RootFormatVisitor.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/RootFormatVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/SdkLiteralTypeModule.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/SdkLiteralTypeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/SdkTypeModule.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/SdkTypeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/VariableMapVisitor.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/VariableMapVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/CustomSdkBindingDataDeserializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/CustomSdkBindingDataDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/CustomSdkBindingDataDeserializers.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/CustomSdkBindingDataDeserializers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/JsonTokenUtil.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/JsonTokenUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/LiteralMapDeserializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/LiteralMapDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/LiteralMapDeserializers.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/LiteralMapDeserializers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/LiteralStructDeserializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/LiteralStructDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/SdkBindingDataDeserializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/SdkBindingDataDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/SdkBindingDataDeserializers.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/deserializers/SdkBindingDataDeserializers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/BindingMapSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/BindingMapSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/BindingMapSerializers.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/BindingMapSerializers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/BlobSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/BlobSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/BooleanSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/BooleanSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/CollectionSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/CollectionSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/DatetimeSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/DatetimeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/DurationSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/DurationSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/FloatSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/FloatSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/GenericSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/GenericSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/IntegerSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/IntegerSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralMapSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralMapSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralMapSerializers.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralMapSerializers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralSerializerFactory.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralSerializerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralTypeSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralTypeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/MapSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/MapSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/PrimitiveSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/PrimitiveSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/ScalarSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/ScalarSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/SdkBindingDataSerializationProtocol.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/SdkBindingDataSerializationProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/SdkBindingDataSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/SdkBindingDataSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/StringSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/StringSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/StructSerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/StructSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkLiteralTypeTest.java
+++ b/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkLiteralTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkTypeTest.java
+++ b/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/pom.xml
+++ b/flytekit-java/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/Compiler.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/Compiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/CompilerError.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/CompilerError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/CompilerException.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/CompilerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/DefaultSdkWorkflowRegistry.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/DefaultSdkWorkflowRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/IfBlockIdl.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/IfBlockIdl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/LiteralTypes.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/LiteralTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/Literals.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/Literals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkAppliedTransform.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkAppliedTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingDataFactory.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBooleanExpression.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBooleanExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBranchNode.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBranchNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkComparisonExpression.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkComparisonExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkCondition.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkConditionCase.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkConditionCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkConditions.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkConditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkConfig.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkConjunctionExpression.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkConjunctionExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkContainerTask.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkContainerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkContainerTaskRegistrar.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkContainerTaskRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkCronSchedule.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkCronSchedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkDynamicWorkflowTask.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkDynamicWorkflowTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkDynamicWorkflowTaskRegistrar.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkDynamicWorkflowTaskRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkIfBlock.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkIfBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkIfElseBlock.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkIfElseBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkLaunchPlan.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkLaunchPlan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkLaunchPlanRegistrar.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkLaunchPlanRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkLaunchPlanRegistry.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkLaunchPlanRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkLiteralType.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkLiteralType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkLiteralTypes.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkLiteralTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkMetadataDecoratorTransform.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkMetadataDecoratorTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkNode.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkNodeMetadata.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkNodeMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkNodeNamePolicy.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkNodeNamePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkRemoteLaunchPlan.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkRemoteLaunchPlan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkRemoteTask.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkRemoteTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkResources.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkRunnableTask.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkRunnableTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkRunnableTaskRegistrar.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkRunnableTaskRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkStruct.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkStruct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkTaskNode.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkTaskNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkTransform.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkType.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkTypes.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflow.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflowBuilder.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflowBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflowMetadata.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflowMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflowNode.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflowNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflowRegistry.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflowRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflowTemplateRegistrar.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkWorkflowTemplateRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SimpleSdkLaunchPlanRegistry.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SimpleSdkLaunchPlanRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/UnaryVariableSdkType.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/UnaryVariableSdkType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/main/java/org/flyte/flytekit/WorkflowTemplateIdl.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/WorkflowTemplateIdl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/LiteralsTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/LiteralsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkBindingDataFactoryTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkBindingDataFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkContainerTaskRegistrarTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkContainerTaskRegistrarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkCronScheduleTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkCronScheduleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkDynamicWorkflowTaskRegistrarTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkDynamicWorkflowTaskRegistrarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkLaunchPlanRegistrarTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkLaunchPlanRegistrarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkLaunchPlanTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkLaunchPlanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkLiteralTypesTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkLiteralTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkNodeNamePolicyTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkNodeNamePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkRemoteLaunchPlanTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkRemoteLaunchPlanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkRemoteTaskTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkRemoteTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkRunnableTaskRegistrarTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkRunnableTaskRegistrarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkTransformTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkWorkflowBuilderTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkWorkflowBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkWorkflowRegistryTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkWorkflowRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkWorkflowTemplateRegistrarTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkWorkflowTemplateRegistrarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SdkWorkflowWithSdkRemoteLaunchPlanTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SdkWorkflowWithSdkRemoteLaunchPlanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/SimpleSdkLaunchPlanTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/SimpleSdkLaunchPlanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/TestPairIntegerInput.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/TestPairIntegerInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/TestUnaryBooleanOutput.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/TestUnaryBooleanOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/TestUnaryIntegerInput.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/TestUnaryIntegerInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/TestUnaryIntegerOutput.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/TestUnaryIntegerOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-java/src/test/java/org/flyte/flytekit/UnaryVariableSdkTypeTest.java
+++ b/flytekit-java/src/test/java/org/flyte/flytekit/UnaryVariableSdkTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/pom.xml
+++ b/flytekit-local-engine/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/BooleanExpressionEvaluator.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/BooleanExpressionEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/ChainedExecutionListener.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/ChainedExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionBranchNode.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionBranchNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionContext.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionIfBlock.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionIfBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionListener.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionNode.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionNodeCompiler.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/ExecutionNodeCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/LocalEngine.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/LocalEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/NoopExecutionListener.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/NoopExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/main/java/org/flyte/localengine/RunnableLaunchPlan.java
+++ b/flytekit-local-engine/src/main/java/org/flyte/localengine/RunnableLaunchPlan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/BooleanExpressionEvaluatorTest.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/BooleanExpressionEvaluatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/ChainedExecutionListenerTest.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/ChainedExecutionListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/ExecutionBranchNodeTest.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/ExecutionBranchNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/ExecutionNodeCompilerTest.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/ExecutionNodeCompilerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/ImmutableList.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/ImmutableList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/ImmutableMap.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/ImmutableMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/LocalEngineTest.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/LocalEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/TestingListener.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/TestingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/CollatzConjectureStepWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/CollatzConjectureStepWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/FibonacciWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/FibonacciWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/InnerSubWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/InnerSubWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/ListTask.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/ListTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/ListWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/ListWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/MapTask.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/MapTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/MapWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/MapWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/NestedSubWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/NestedSubWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/OuterSubWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/OuterSubWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/RetryableTask.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/RetryableTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/RetryableWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/RetryableWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/StructTask.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/StructTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/StructWorkflow.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/StructWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/SumTask.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/SumTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/TestTuple3IntegerInput.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/TestTuple3IntegerInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/TestUnaryIntegerOutput.java
+++ b/flytekit-local-engine/src/test/java/org/flyte/localengine/examples/TestUnaryIntegerOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala-tests/pom.xml
+++ b/flytekit-scala-tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataConvertersTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataFactoryTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkBindingDataFactoryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkLiteralTypesTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkLiteralTypesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkScalaTypeTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkScalaTypeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala_2.12/pom.xml
+++ b/flytekit-scala_2.12/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-scala_2.13/pom.xml
+++ b/flytekit-scala_2.13/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/package.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataConverters.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataConverters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataFactory.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkScalaType.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkScalaType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2020-2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkScalaWorkflow.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkScalaWorkflow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors.
+ * Copyright 2023 Flyte Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/pom.xml
+++ b/flytekit-testing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/LiteralTypes.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/LiteralTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/Literals.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/Literals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/Preconditions.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/Preconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/SdkTestingExecutor.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/SdkTestingExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableLaunchPlan.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableLaunchPlan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableNode.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableTask.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingRunnableTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingWorkflow.java
+++ b/flytekit-testing/src/main/java/org/flyte/flytekit/testing/TestingWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/FibonacciWorkflowTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/FibonacciWorkflowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/IfElseWorkflowTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/IfElseWorkflowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/LiteralTypesTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/LiteralTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/RemoteSumTask.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/RemoteSumTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/RemoteVoidOutputTask.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/RemoteVoidOutputTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/SdkTestingExecutorTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/SdkTestingExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/SumTask.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/SumTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/TestingRunnableNodeTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/TestingRunnableNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/flyte/integrationtests/BranchNodeWorkflow.java
+++ b/integration-tests/src/main/java/org/flyte/integrationtests/BranchNodeWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/flyte/integrationtests/ConstStringTask.java
+++ b/integration-tests/src/main/java/org/flyte/integrationtests/ConstStringTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/flyte/integrationtests/FailingTask.java
+++ b/integration-tests/src/main/java/org/flyte/integrationtests/FailingTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/flyte/integrationtests/LaunchPlanRegistry.java
+++ b/integration-tests/src/main/java/org/flyte/integrationtests/LaunchPlanRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/flyte/integrationtests/structs/BQReference.java
+++ b/integration-tests/src/main/java/org/flyte/integrationtests/structs/BQReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/flyte/integrationtests/structs/BuildBqReference.java
+++ b/integration-tests/src/main/java/org/flyte/integrationtests/structs/BuildBqReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/flyte/integrationtests/structs/MockLookupBqTask.java
+++ b/integration-tests/src/main/java/org/flyte/integrationtests/structs/MockLookupBqTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/flyte/integrationtests/structs/MockPipelineWorkflow.java
+++ b/integration-tests/src/main/java/org/flyte/integrationtests/structs/MockPipelineWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/flyte/AdditionalIT.java
+++ b/integration-tests/src/test/java/org/flyte/AdditionalIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/flyte/FlyteContainer.java
+++ b/integration-tests/src/test/java/org/flyte/FlyteContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/flyte/JavaExamplesIT.java
+++ b/integration-tests/src/test/java/org/flyte/JavaExamplesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/flyte/SerializeJavaIT.java
+++ b/integration-tests/src/test/java/org/flyte/SerializeJavaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/flyte/utils/FlyteSandboxClient.java
+++ b/integration-tests/src/test/java/org/flyte/utils/FlyteSandboxClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/flyte/utils/FlyteSandboxContainer.java
+++ b/integration-tests/src/test/java/org/flyte/utils/FlyteSandboxContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/flyte/utils/JFlyteContainer.java
+++ b/integration-tests/src/test/java/org/flyte/utils/JFlyteContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/flyte/utils/Literal.java
+++ b/integration-tests/src/test/java/org/flyte/utils/Literal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/flyte/utils/NotRunningWaitStrategy.java
+++ b/integration-tests/src/test/java/org/flyte/utils/NotRunningWaitStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-api/pom.xml
+++ b/jflyte-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/jflyte-api/src/main/java/org/flyte/jflyte/api/FileSystem.java
+++ b/jflyte-api/src/main/java/org/flyte/jflyte/api/FileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-api/src/main/java/org/flyte/jflyte/api/FileSystemRegistrar.java
+++ b/jflyte-api/src/main/java/org/flyte/jflyte/api/FileSystemRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-api/src/main/java/org/flyte/jflyte/api/Manifest.java
+++ b/jflyte-api/src/main/java/org/flyte/jflyte/api/Manifest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-api/src/main/java/org/flyte/jflyte/api/Token.java
+++ b/jflyte-api/src/main/java/org/flyte/jflyte/api/Token.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-api/src/main/java/org/flyte/jflyte/api/TokenSource.java
+++ b/jflyte-api/src/main/java/org/flyte/jflyte/api/TokenSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-api/src/main/java/org/flyte/jflyte/api/TokenSourceFactory.java
+++ b/jflyte-api/src/main/java/org/flyte/jflyte/api/TokenSourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-api/src/main/java/org/flyte/jflyte/api/TokenSourceFactoryRegistrar.java
+++ b/jflyte-api/src/main/java/org/flyte/jflyte/api/TokenSourceFactoryRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-aws/pom.xml
+++ b/jflyte-aws/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/jflyte-aws/src/main/java/org/flyte/jflyte/aws/S3FileSystem.java
+++ b/jflyte-aws/src/main/java/org/flyte/jflyte/aws/S3FileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-aws/src/main/java/org/flyte/jflyte/aws/S3FileSystemRegistrar.java
+++ b/jflyte-aws/src/main/java/org/flyte/jflyte/aws/S3FileSystemRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-aws/src/main/java/org/flyte/jflyte/aws/S3WritableByteChannel.java
+++ b/jflyte-aws/src/main/java/org/flyte/jflyte/aws/S3WritableByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-aws/src/test/java/org/flyte/jflyte/aws/S3FileSystemIT.java
+++ b/jflyte-aws/src/test/java/org/flyte/jflyte/aws/S3FileSystemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-google-cloud/pom.xml
+++ b/jflyte-google-cloud/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/jflyte-google-cloud/src/main/java/org/flyte/jflyte/gcp/GcpTokenSource.java
+++ b/jflyte-google-cloud/src/main/java/org/flyte/jflyte/gcp/GcpTokenSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-google-cloud/src/main/java/org/flyte/jflyte/gcp/GcsFileSystem.java
+++ b/jflyte-google-cloud/src/main/java/org/flyte/jflyte/gcp/GcsFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-google-cloud/src/main/java/org/flyte/jflyte/gcp/GcsFileSystemRegistrar.java
+++ b/jflyte-google-cloud/src/main/java/org/flyte/jflyte/gcp/GcsFileSystemRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-google-cloud/src/main/java/org/flyte/jflyte/gcp/GoogleAuthHelper.java
+++ b/jflyte-google-cloud/src/main/java/org/flyte/jflyte/gcp/GoogleAuthHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-google-cloud/src/test/java/org/flyte/jflyte/gcp/GcsFileSystemTest.java
+++ b/jflyte-google-cloud/src/test/java/org/flyte/jflyte/gcp/GcsFileSystemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/pom.xml
+++ b/jflyte-utils/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2023 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/Artifact.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/Artifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ArtifactStager.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ArtifactStager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/AuthorizationHeaderInterceptor.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/AuthorizationHeaderInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ChildFirstClassLoader.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ChildFirstClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ClassLoaders.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ClassLoaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/CompletableFutures.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/CompletableFutures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/Config.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ExecutionConfig.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ExecutionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/FileSystemLoader.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/FileSystemLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/FlyteAdminClient.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/FlyteAdminClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/GrpcRetries.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/GrpcRetries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/IdentifierRewrite.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/IdentifierRewrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/JFlyteCustom.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/JFlyteCustom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/MoreCollectors.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/MoreCollectors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/PackageLoader.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/PackageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ProjectClosure.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ProjectClosure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ProtoReader.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ProtoReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ProtoUtil.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ProtoUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ProtoWriter.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ProtoWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/QuantityUtil.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/QuantityUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/Registrars.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/Registrars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/TaskSpec.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/TaskSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/TokenSourceFactoryLoader.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/TokenSourceFactoryLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/WorkflowNodeVisitor.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/WorkflowNodeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/WorkflowSpec.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/WorkflowSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ApiUtils.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ApiUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/AuthorizationHeaderInterceptorTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/AuthorizationHeaderInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ChildFirstClassLoaderTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ChildFirstClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/CompletableFuturesTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/CompletableFuturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/FileSystemExtension.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/FileSystemExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/FlyteAdminClientTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/FlyteAdminClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/GrpcRetriesTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/GrpcRetriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/GrpcUtils.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/GrpcUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/IdentifierRewriteTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/IdentifierRewriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/InMemoryFileSystem.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/InMemoryFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/JFlyteCustomTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/JFlyteCustomTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProjectClosureTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProjectClosureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProtoReaderTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProtoReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProtoUtilTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProtoUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProtoWriterTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProtoWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/QuantityUtilTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/QuantityUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2022-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/TestAdminService.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/TestAdminService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/pom.xml
+++ b/jflyte/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/Execute.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/Execute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/ExecuteDynamicWorkflow.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/ExecuteDynamicWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/ExecuteLocal.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/ExecuteLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/ExecuteLocalArgsParser.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/ExecuteLocalArgsParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/ExecuteLocalLoader.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/ExecuteLocalLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/LiteralTypeConverter.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/LiteralTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/Main.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/Modules.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/Modules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/RegisterWorkflows.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/RegisterWorkflows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/SerializeWorkflows.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/SerializeWorkflows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2021-2023 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/main/java/org/flyte/jflyte/StringUtil.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/StringUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/test/java/org/flyte/jflyte/ApiUtils.java
+++ b/jflyte/src/test/java/org/flyte/jflyte/ApiUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/test/java/org/flyte/jflyte/ExecuteLocalArgsParserTest.java
+++ b/jflyte/src/test/java/org/flyte/jflyte/ExecuteLocalArgsParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2022 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/test/java/org/flyte/jflyte/ExecuteLocalLoaderTest.java
+++ b/jflyte/src/test/java/org/flyte/jflyte/ExecuteLocalLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jflyte/src/test/java/org/flyte/jflyte/StringUtilTest.java
+++ b/jflyte/src/test/java/org/flyte/jflyte/StringUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Flyte Authors
+ * Copyright 2020-2021 Flyte Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Flyte Authors.
+  Copyright 2020-2023 Flyte Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
# TL;DR
Similar as #246, but only have years when we really made change.

This is done by `mvn spotless:apply -DspotlessSetLicenseHeaderYearsFromGitHistory=true`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
_NA_

## Follow-up issue
_NA_
