### PR TITLE
Fix bom by appending scala version

### DIFF
--- a/flytekit-bom/pom.xml
+++ b/flytekit-bom/pom.xml
@@ -82,11 +82,6 @@
       </dependency>
       <dependency>
         <groupId>org.flyte</groupId>
-        <artifactId>flytekit-scala_2.12</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.flyte</groupId>
         <artifactId>flytekit-scala_2.13</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/flytekit-bom/pom.xml
+++ b/flytekit-bom/pom.xml
@@ -92,7 +92,7 @@
       </dependency>
       <dependency>
         <groupId>org.flyte</groupId>
-        <artifactId>flytekit-scala-tests</artifactId>
+        <artifactId>flytekit-scala-tests_2.13</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/flytekit-bom/pom.xml
+++ b/flytekit-bom/pom.xml
@@ -82,6 +82,11 @@
       </dependency>
       <dependency>
         <groupId>org.flyte</groupId>
+        <artifactId>flytekit-scala_2.12</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.flyte</groupId>
         <artifactId>flytekit-scala_2.13</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
# TL;DR
Fix bom by appending scala version because of scala.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Scala should be versioned otherwise the dependency is wrong. ~~We also have to remove 2.12 out because there will always be conflicting between 2.12 and 2.13 if they stay in the same bom~~. Nah, this is only dependency management after all, and it's up to the user to pick and choose.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
