### PR TITLE
Describe known inputs when input type not found in TestingRunnableNode

### DIFF
--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/SdkTestingExecutorTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/SdkTestingExecutorTest.java
@@ -253,7 +253,10 @@ public class SdkTestingExecutorTest {
     assertThat(
         e.getMessage(),
         equalTo(
-            "Can't find input RemoteSumInput{a=SdkBindingData{type=integers, value=1}, b=SdkBindingData{type=integers, value=2}} for remote task [remote_sum_task] across known task inputs, use SdkTestingExecutor#withTaskOutput or SdkTestingExecutor#withTask to provide a test double"));
+            "Can't find input for remote task [remote_sum_task] across known task inputs.\n"
+                + "Input: RemoteSumInput{a=SdkBindingData{type=integers, value=1}, b=SdkBindingData{type=integers, value=2}}\n"
+                + "Known inputs: RemoteSumInput{a=SdkBindingData{type=integers, value=10}, b=SdkBindingData{type=integers, value=20}}\n"
+                + "Use SdkTestingExecutor#withTaskOutput or SdkTestingExecutor#withTask to provide a test double"));
   }
 
   @Test
@@ -383,7 +386,10 @@ public class SdkTestingExecutorTest {
     assertThat(
         ex.getMessage(),
         equalTo(
-            "Can't find input SumLaunchPlanInput{a=SdkBindingData{type=integers, value=3}, b=SdkBindingData{type=integers, value=5}} for remote launch plan [SumWorkflow] across known launch plan inputs, use SdkTestingExecutor#withLaunchPlanOutput or SdkTestingExecutor#withLaunchPlan to provide a test double"));
+            "Can't find input for remote launch plan [SumWorkflow] across known launch plan inputs."
+                + "\nInput: SumLaunchPlanInput{a=SdkBindingData{type=integers, value=3}, b=SdkBindingData{type=integers, value=5}}"
+                + "\nKnown inputs: SumLaunchPlanInput{a=SdkBindingData{type=integers, value=100000}, b=SdkBindingData{type=integers, value=100000}}"
+                + "\nUse SdkTestingExecutor#withLaunchPlanOutput or SdkTestingExecutor#withLaunchPlan to provide a test double"));
   }
 
   @Test
@@ -504,7 +510,10 @@ public class SdkTestingExecutorTest {
     assertThat(
         e.getMessage(),
         equalTo(
-            "Can't find input RemoteSumInput{a=SdkBindingData{type=integers, value=1}, b=SdkBindingData{type=integers, value=2}} for remote task [remote_sum_task] across known task inputs, use SdkTestingExecutor#withTaskOutput or SdkTestingExecutor#withTask to provide a test double"));
+            "Can't find input for remote task [remote_sum_task] across known task inputs.\n"
+                + "Input: RemoteSumInput{a=SdkBindingData{type=integers, value=1}, b=SdkBindingData{type=integers, value=2}}\n"
+                + "Known inputs: RemoteSumInput{a=SdkBindingData{type=integers, value=10}, b=SdkBindingData{type=integers, value=20}}\n"
+                + "Use SdkTestingExecutor#withTaskOutput or SdkTestingExecutor#withTask to provide a test double"));
   }
 
   public static class SimpleUberWorkflow

--- a/flytekit-testing/src/test/java/org/flyte/flytekit/testing/TestingRunnableNodeTest.java
+++ b/flytekit-testing/src/test/java/org/flyte/flytekit/testing/TestingRunnableNodeTest.java
@@ -21,6 +21,7 @@ import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.auto.value.AutoValue;
@@ -70,7 +71,10 @@ class TestingRunnableNodeTest {
 
   @Test
   void testRun_notFound() {
-    Map<Input, Output> fixedOutputs = singletonMap(Input.create("7"), Output.create(7L));
+    Map<Input, Output> fixedOutputs =
+        Map.of(
+            Input.create("7"), Output.create(7L),
+            Input.create("8"), Output.create(8L));
     TestNode node = new TestNode(null, fixedOutputs);
 
     IllegalArgumentException ex =
@@ -80,9 +84,17 @@ class TestingRunnableNodeTest {
 
     assertThat(
         ex.getMessage(),
-        equalTo(
-            "Can't find input Input{in=SdkBindingData{type=strings, value=not in fixed outputs}} for remote test [TestTask] "
-                + "across known test inputs, use a magic wang to provide a test double"));
+        oneOf(
+            "Can't find input for remote test [TestTask] across known test inputs.\n"
+                + "Input: Input{in=SdkBindingData{type=strings, value=not in fixed outputs}}\n"
+                + "Known inputs: Input{in=SdkBindingData{type=strings, value=8}}\n"
+                + "Input{in=SdkBindingData{type=strings, value=7}}\n"
+                + "Use a magic wang to provide a test double",
+            "Can't find input for remote test [TestTask] across known test inputs.\n"
+                + "Input: Input{in=SdkBindingData{type=strings, value=not in fixed outputs}}\n"
+                + "Known inputs: Input{in=SdkBindingData{type=strings, value=7}}\n"
+                + "Input{in=SdkBindingData{type=strings, value=8}}\n"
+                + "Use a magic wang to provide a test double"));
   }
 
   @Test
@@ -128,8 +140,10 @@ class TestingRunnableNodeTest {
     assertThat(
         ex.getMessage(),
         equalTo(
-            "Can't find input Input{in=SdkBindingData{type=strings, value=7}} for remote test [TestTask] "
-                + "across known test inputs, use a magic wang to provide a test double"));
+            "Can't find input for remote test [TestTask] across known test inputs.\n"
+                + "Input: Input{in=SdkBindingData{type=strings, value=7}}\n"
+                + "Known inputs: {}\n"
+                + "Use a magic wang to provide a test double"));
   }
 
   @Test


### PR DESCRIPTION
# TL;DR
When attempting a workflow test, there can be failures setting up the test when incorrect parameters are used. It is not immediately obvious from the current exception message where the difference is between expected and actual.
Here I have included the known inputs that are checked when setting up the test so that the user has a better idea of what is wrong. 

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
I had to create workflow tests with several LaunchPlanOutput/TaskOutput for bigquery, gcs, dataflow jobs, etc. Because of the large number of parameters I was using it was helpful for me to debug `TestingRunnableNode` when I got the initial error message to compare my input with the known inputs. I thought a more detailed error message could be of use to someone facing the same problem. 

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
