### PR TITLE
Recursively handle subworkflow in dynamic

### DIFF
--- a/flytekit-examples/src/main/java/org/flyte/examples/DynamicFibonacciWorkflowTask.java
+++ b/flytekit-examples/src/main/java/org/flyte/examples/DynamicFibonacciWorkflowTask.java
@@ -87,13 +87,19 @@ public class DynamicFibonacciWorkflowTask
                       SdkTypes.nulls(),
                       SdkTypes.nulls())
                   .withUpstreamNode(hello));
+      // subworkflow that contains another subworkflow
+      SdkNode<WelcomeWorkflow.Output> greet =
+          builder.apply(
+              "greet",
+              new SubWorkflow().withUpstreamNode(world),
+              WelcomeWorkflow.Input.create(SdkBindingDataFactory.of("greet")));
       @Var SdkBindingData<Long> prev = SdkBindingDataFactory.of(0);
       @Var SdkBindingData<Long> value = SdkBindingDataFactory.of(1);
       for (int i = 2; i <= input.n().get(); i++) {
         SdkBindingData<Long> next =
             builder
                 .apply(
-                    "fib-" + i, new SumTask().withUpstreamNode(world), SumInput.create(value, prev))
+                    "fib-" + i, new SumTask().withUpstreamNode(greet), SumInput.create(value, prev))
                 .getOutputs();
         prev = value;
         value = next;

--- a/jflyte/src/main/java/org/flyte/jflyte/ExecuteDynamicWorkflow.java
+++ b/jflyte/src/main/java/org/flyte/jflyte/ExecuteDynamicWorkflow.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.flyte.api.v1.Binding;
 import org.flyte.api.v1.BindingData;
@@ -202,8 +203,8 @@ public class ExecuteDynamicWorkflow implements Callable<Integer> {
       Config config,
       ExecutionConfig executionConfig,
       DynamicJobSpec spec,
-      Map<TaskIdentifier, TaskTemplate> taskTemplates,
-      Map<WorkflowIdentifier, WorkflowTemplate> workflowTemplates) {
+      Map<TaskIdentifier, TaskTemplate> allTaskTemplates,
+      Map<WorkflowIdentifier, WorkflowTemplate> allWorkflowTemplates) {
 
     try (FlyteAdminClient flyteAdminClient =
         FlyteAdminClient.create(config.platformUrl(), config.platformInsecure(), null)) {
@@ -216,24 +217,25 @@ public class ExecuteDynamicWorkflow implements Callable<Integer> {
               .adminClient(flyteAdminClient)
               .build()
               .visitor();
+      Function<List<Node>, List<Node>> nodesRewriter =
+          nodes -> nodes.stream().map(workflowNodeVisitor::visitNode).collect(toUnmodifiableList());
+
+      Map<WorkflowIdentifier, WorkflowTemplate> allUsedSubWorkflows =
+          collectAllUsedSubWorkflows(
+              spec.nodes(), allWorkflowTemplates, workflowNodeVisitor, nodesRewriter);
 
       Map<TaskIdentifier, TaskTemplate> allUsedTaskTemplates = new HashMap<>();
-      Map<WorkflowIdentifier, WorkflowTemplate> allUsedSubWorkflows = new HashMap<>();
-      Map<TaskIdentifier, TaskTemplate> cache = new HashMap<>();
-
-      List<Node> nodes =
-          recursivelyCollect(
-              spec.nodes(),
+      List<Node> rewrittenNodes =
+          collectAllUsedTaskTemplates(
+              spec,
+              allTaskTemplates,
+              nodesRewriter,
               allUsedTaskTemplates,
-              allUsedSubWorkflows,
-              taskTemplates,
-              workflowTemplates,
-              workflowNodeVisitor,
               flyteAdminClient,
-              cache);
+              allUsedSubWorkflows);
 
       return spec.toBuilder()
-          .nodes(nodes)
+          .nodes(rewrittenNodes)
           .subWorkflows(
               ImmutableMap.<WorkflowIdentifier, WorkflowTemplate>builder()
                   .putAll(spec.subWorkflows())
@@ -248,44 +250,67 @@ public class ExecuteDynamicWorkflow implements Callable<Integer> {
     }
   }
 
-  private static List<Node> recursivelyCollect(
-      List<Node> startPoint,
-      Map<TaskIdentifier, TaskTemplate> allUsedTaskTemplates,
-      Map<WorkflowIdentifier, WorkflowTemplate> allUsedSubWorkflows,
+  private static List<Node> collectAllUsedTaskTemplates(
+      DynamicJobSpec spec,
       Map<TaskIdentifier, TaskTemplate> allTaskTemplates,
-      Map<WorkflowIdentifier, WorkflowTemplate> allWorkflowTemplates,
+      Function<List<Node>, List<Node>> nodesRewriter,
+      Map<TaskIdentifier, TaskTemplate> allUsedTaskTemplates,
+      FlyteAdminClient flyteAdminClient,
+      Map<WorkflowIdentifier, WorkflowTemplate> allUsedSubWorkflows) {
+
+    Map<TaskIdentifier, TaskTemplate> cache = new HashMap<>();
+
+    // collect directly used task templates
+    List<Node> rewrittenNodes =
+        collectTaskTemplates(
+            spec.nodes(),
+            nodesRewriter,
+            allUsedTaskTemplates,
+            allTaskTemplates,
+            flyteAdminClient,
+            cache);
+
+    // collect task templates used by subworkflows
+    allUsedSubWorkflows
+        .values()
+        .forEach(
+            workflowTemplate ->
+                collectTaskTemplates(
+                    workflowTemplate.nodes(),
+                    nodesRewriter,
+                    allUsedTaskTemplates,
+                    allTaskTemplates,
+                    flyteAdminClient,
+                    cache));
+
+    return rewrittenNodes;
+  }
+
+  private static Map<WorkflowIdentifier, WorkflowTemplate> collectAllUsedSubWorkflows(
+      List<Node> nodes,
+      Map<WorkflowIdentifier, WorkflowTemplate> workflowTemplates,
       WorkflowNodeVisitor workflowNodeVisitor,
+      Function<List<Node>, List<Node>> nodesRewriter) {
+
+    Map<WorkflowIdentifier, WorkflowTemplate> allUsedSubWorkflows =
+        ProjectClosure.collectSubWorkflows(nodes, workflowTemplates, nodesRewriter);
+    return mapValues(allUsedSubWorkflows, workflowNodeVisitor::visitWorkflowTemplate);
+  }
+
+  private static List<Node> collectTaskTemplates(
+      List<Node> nodes,
+      Function<List<Node>, List<Node>> nodesRewriter,
+      Map<TaskIdentifier, TaskTemplate> allUsedTaskTemplates,
+      Map<TaskIdentifier, TaskTemplate> allTaskTemplates,
       FlyteAdminClient flyteAdminClient,
       Map<TaskIdentifier, TaskTemplate> cache) {
 
-    List<Node> rewrittenNodes =
-        startPoint.stream().map(workflowNodeVisitor::visitNode).collect(toUnmodifiableList());
+    List<Node> rewrittenNodes = nodesRewriter.apply(nodes);
 
     Map<TaskIdentifier, TaskTemplate> usedTaskTemplates =
         ProjectClosure.collectDynamicWorkflowTasks(
             rewrittenNodes, allTaskTemplates, id -> fetchTaskTemplate(flyteAdminClient, id, cache));
     allUsedTaskTemplates.putAll(usedTaskTemplates);
-
-    Map<WorkflowIdentifier, WorkflowTemplate> usedSubWorkflows =
-        ProjectClosure.collectSubWorkflows(rewrittenNodes, allWorkflowTemplates);
-    Map<WorkflowIdentifier, WorkflowTemplate> rewrittenUsedSubWorkflows =
-        mapValues(usedSubWorkflows, workflowNodeVisitor::visitWorkflowTemplate);
-
-    rewrittenUsedSubWorkflows.forEach(
-        (key, value) -> {
-          if (!allUsedSubWorkflows.containsKey(key)) {
-            allUsedSubWorkflows.put(key, value);
-            recursivelyCollect(
-                value.nodes(),
-                allUsedTaskTemplates,
-                allUsedSubWorkflows,
-                allTaskTemplates,
-                allWorkflowTemplates,
-                workflowNodeVisitor,
-                flyteAdminClient,
-                cache);
-          }
-        });
 
     return rewrittenNodes;
   }


### PR DESCRIPTION
# TL;DR
Recursively handle subworkflow in dynamic

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Today subworkflow in dynamic task does not really work because we are not including all referenced task templates and propeller fails the compilation. This PR fixes that by recursively collecting all referenced task templates to include them in the dynamic job proto.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
