### PR TITLE
Case class for BindingCollection/Map

### DIFF
--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
@@ -23,7 +23,7 @@ import org.flyte.flytekitscala.SdkLiteralTypes.collections
 import java.util.function
 import scala.collection.JavaConverters._
 
-private[flyte] class BindingCollection[T](
+private[flyte] case class BindingCollection[T](
     elementType: SdkLiteralType[T],
     bindingCollection: List[SdkBindingData[T]]
 ) extends SdkBindingData[List[T]] {

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingCollection.scala
@@ -17,7 +17,6 @@
 package org.flyte.flytekit
 
 import org.flyte.api.v1.BindingData
-import org.flyte.flytekit.SdkBindingData.Literal
 import org.flyte.flytekitscala.SdkLiteralTypes.collections
 
 import java.util.function

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
@@ -23,7 +23,7 @@ import org.flyte.flytekitscala.SdkLiteralTypes.maps
 import java.util.function
 import scala.collection.JavaConverters._
 
-private[flyte] class BindingMap[T](
+private[flyte] case class BindingMap[T](
     valuesType: SdkLiteralType[T],
     bindingMap: Map[String, SdkBindingData[T]]
 ) extends SdkBindingData[Map[String, T]] {

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/BindingMap.scala
@@ -17,7 +17,6 @@
 package org.flyte.flytekit
 
 import org.flyte.api.v1.BindingData
-import org.flyte.flytekit.SdkBindingData.Literal
 import org.flyte.flytekitscala.SdkLiteralTypes.maps
 
 import java.util.function

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/package.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekit/package.scala
@@ -18,10 +18,9 @@ package org.flyte
 
 /** Contains subclasses for [[SdkBindingData]]. We are forced to define this
   * package here because [[SdkBindingData#idl()]] is package private (we don´t
-  * want to expose it to users). We cannot make it protected either as it would
-  * be good for the own object but both implementations deal with list or maps
-  * of [[SdkBindingData]] and therefore cannot call this method because it is in
-  * a different class.
+  * want to expose it to users). Making it protected doesn't help either because
+  * list or map needs to call this method of elements so that requires it to be
+  * public.
   *
   * This is not ideal because we are splitting the flytekit package in two maven
   * modules. This would create problems when we decide to add java 9 style

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataFactory.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataFactory.scala
@@ -353,7 +353,7 @@ object SdkBindingDataFactory {
       elementType: SdkLiteralType[T],
       elements: List[SdkBindingData[T]]
   ): SdkBindingData[List[T]] = {
-    new BindingCollection(elementType, elements)
+    BindingCollection(elementType, elements)
   }
 
   /** Creates a [[SdkBindingData]] for a flyte map given a java
@@ -372,7 +372,7 @@ object SdkBindingDataFactory {
       valuesType: SdkLiteralType[T],
       valueMap: Map[String, SdkBindingData[T]]
   ): SdkBindingData[Map[String, T]] =
-    new BindingMap(valuesType, valueMap)
+    BindingMap(valuesType, valueMap)
 
   private def toSdkLiteralType(
       value: Any,


### PR DESCRIPTION
# TL;DR
Make Scala `BindingCollection` and `BindingMap` case classes.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Making them case classes to be able to support equality check. They should have been case classes in the first place, so this is a bug fix.

This change should have no user impact because both classes are package private.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
