### PR TITLE
Better way to get product elements

### DIFF
--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
@@ -229,11 +229,7 @@ object SdkLiteralTypes {
 
   private def toStruct(product: Product): Struct = {
     def productToMap(product: Product): Map[String, Any] = {
-      // by spec getDeclaredFields is not ordered but in practice it works fine
-      // it's a lot better since Scala 2.13 because productElementNames was introduced
-      //   (product.productElementNames zip product.productIterator).toMap
-      product.getClass.getDeclaredFields
-        .map(_.getName)
+      productElementNames(product)
         .zip(product.productIterator.toList)
         .toMap
     }

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkScalaType.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkScalaType.scala
@@ -165,8 +165,7 @@ object SdkScalaType {
       ): ju.Map[String, SdkBindingData[_]] = {
         value match {
           case product: Product =>
-            value.getClass.getDeclaredFields
-              .map(_.getName)
+            productElementNames(product)
               .zip(product.productIterator.toSeq)
               .toMap
               .mapValues {

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/package.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/package.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Flyte Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte
+
+package object flytekitscala {
+  private[flytekitscala] def productElementNames(
+      product: Product
+  ): List[String] = {
+    try {
+      // scala 2.13
+      product.getClass
+        .getMethod("productElementNames")
+        .invoke(product)
+        .asInstanceOf[Iterator[String]]
+        .toList
+    } catch {
+      case _: Throwable =>
+        // fall back to java's way but less reliable
+        product.getClass.getDeclaredFields.map(_.getName).toList
+    }
+  }
+}

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/package.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/package.scala
@@ -29,7 +29,7 @@ package object flytekitscala {
         .toList
     } catch {
       case _: Throwable =>
-        // fall back to java's way but less reliable
+        // fall back to java's way, less reliable and with limitations
         product.getClass.getDeclaredFields.map(_.getName).toList
     }
   }


### PR DESCRIPTION
# TL;DR
Prefer using Scala 2.13's way to get product element names

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added (covered by IT)
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Since most users should have been on Scala 2.13, we can have a better way to get product element names, with fallback to Java's way.

`getDeclaredFields` from Java is less reliable, and it doesn't get super classes' declared fields. We could do that ourselves, but it is impossible to get the correct order.

For case class like:

```scala
class B(val a: String, val b: String)

case class A(override val a: String, c: String, override val b: String) extends B(a, b)
```
`productElementNames` can correctly get `[a, c, b]` for instance of `A`, but `getDeclaredFields` can only get `c` for instance of `A`. It won't work if we try to recursively go up to get all declared fields, because we would not be able to put up a correct order where `c` appears between `a` and `b`.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
