### PR TITLE
Handle Option correctly

### DIFF
--- a/flytekit-examples-scala/src/main/resources/META-INF/services/org.flyte.flytekit.SdkRunnableTask
+++ b/flytekit-examples-scala/src/main/resources/META-INF/services/org.flyte.flytekit.SdkRunnableTask
@@ -4,3 +4,4 @@ org.flyte.examples.flytekitscala.GreetTask
 org.flyte.examples.flytekitscala.AddQuestionTask
 org.flyte.examples.flytekitscala.NoInputsTask
 org.flyte.examples.flytekitscala.NestedIOTask
+org.flyte.examples.flytekitscala.NestedIOTaskNoop

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/LaunchPlanRegistry.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/LaunchPlanRegistry.scala
@@ -73,14 +73,19 @@ class LaunchPlanRegistry extends SimpleSdkLaunchPlanRegistry {
             6.toDouble,
             "hello",
             List("1", "2"),
-            List(NestedNested(7.toDouble, NestedNestedNested("world"))),
+            List(NestedNested(7.toDouble, Some(NestedNestedNested("world")))),
             Map("1" -> "1", "2" -> "2"),
-            Map("foo" -> NestedNested(7.toDouble, NestedNestedNested("world"))),
+            Map(
+              "foo" -> NestedNested(
+                7.toDouble,
+                Some(NestedNestedNested("world"))
+              )
+            ),
             Some(false),
             None,
             Some(List("3", "4")),
             Some(Map("3" -> "3", "4" -> "4")),
-            NestedNested(7.toDouble, NestedNestedNested("world"))
+            NestedNested(7.toDouble, Some(NestedNestedNested("world")))
           )
         )
       )

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/NestedIOTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/NestedIOTask.scala
@@ -57,9 +57,6 @@ case class NestedIOTaskOutput(
     generic: SdkBindingData[Nested]
 )
 
-/** Example Flyte task that takes a name as the input and outputs a simple
-  * greeting message.
-  */
 class NestedIOTask
     extends SdkRunnableTask[
       NestedIOTaskInput,
@@ -69,17 +66,21 @@ class NestedIOTask
       SdkScalaType[NestedIOTaskOutput]
     ) {
 
-  /** Defines task behavior. This task takes a name as the input, wraps it in a
-    * welcome message, and outputs the message.
-    *
-    * @param input
-    *   the name of the person to be greeted
-    * @return
-    *   the welcome message
-    */
   override def run(input: NestedIOTaskInput): NestedIOTaskOutput =
     NestedIOTaskOutput(
       input.name,
       input.generic
     )
+}
+
+class NestedIOTaskNoop
+    extends SdkRunnableTask[
+      NestedIOTaskOutput,
+      NestedIOTaskOutput
+    ](
+      SdkScalaType[NestedIOTaskOutput],
+      SdkScalaType[NestedIOTaskOutput]
+    ) {
+
+  override def run(input: NestedIOTaskOutput): NestedIOTaskOutput = input
 }

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/NestedIOTask.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/NestedIOTask.scala
@@ -24,7 +24,7 @@ import org.flyte.flytekitscala.{
 }
 
 case class NestedNestedNested(string: String)
-case class NestedNested(double: Double, nested: NestedNestedNested)
+case class NestedNested(double: Double, nested: Option[NestedNestedNested])
 case class Nested(
     boolean: Boolean,
     byte: Byte,

--- a/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/NestedIOWorkflow.scala
+++ b/flytekit-examples-scala/src/main/scala/org/flyte/examples/flytekitscala/NestedIOWorkflow.scala
@@ -32,6 +32,7 @@ class NestedIOWorkflow
       builder: SdkScalaWorkflowBuilder,
       input: NestedIOTaskInput
   ): Unit = {
-    builder.apply(new NestedIOTask(), input)
+    val output = builder.apply(new NestedIOTask(), input)
+    builder.apply(new NestedIOTaskNoop(), output.getOutputs)
   }
 }

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkScalaTypeTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkScalaTypeTest.scala
@@ -183,7 +183,7 @@ class SdkScalaTypeTest {
           Struct.of(
             Map(
               "foo" -> Struct.Value.ofStringValue("foo"),
-              "bar" -> Struct.Value.ofStringValue("bar"),
+              "bar" -> Struct.Value.ofNullValue(),
               "nestedNested" -> Struct.Value.ofStructValue(
                 Struct.of(
                   Map(
@@ -211,7 +211,7 @@ class SdkScalaTypeTest {
           SdkLiteralTypes.generics(),
           ScalarNested(
             "foo",
-            Some("bar"),
+            None,
             Some(ScalarNestedNested("foo", Some("bar")))
           )
         )

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkScalaTypeTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkScalaTypeTest.scala
@@ -49,7 +49,12 @@ import org.flyte.flytekitscala.SdkLiteralTypes.{
 }
 
 // The constructor is reflectedly invoked so it cannot be an inner class
-case class ScalarNested(foo: String, bar: String)
+case class ScalarNested(
+    foo: String,
+    bar: Option[String],
+    nestedNested: Option[ScalarNestedNested]
+)
+case class ScalarNestedNested(foo: String, bar: Option[String])
 
 class SdkScalaTypeTest {
 
@@ -178,7 +183,15 @@ class SdkScalaTypeTest {
           Struct.of(
             Map(
               "foo" -> Struct.Value.ofStringValue("foo"),
-              "bar" -> Struct.Value.ofStringValue("bar")
+              "bar" -> Struct.Value.ofStringValue("bar"),
+              "nestedNested" -> Struct.Value.ofStructValue(
+                Struct.of(
+                  Map(
+                    "foo" -> Struct.Value.ofStringValue("foo"),
+                    "bar" -> Struct.Value.ofStringValue("bar")
+                  ).asJava
+                )
+              )
             ).asJava
           )
         )
@@ -196,7 +209,11 @@ class SdkScalaTypeTest {
         blob = SdkBindingDataFactory.of(blob),
         generic = SdkBindingDataFactory.of(
           SdkLiteralTypes.generics(),
-          ScalarNested("foo", "bar")
+          ScalarNested(
+            "foo",
+            Some("bar"),
+            Some(ScalarNestedNested("foo", Some("bar")))
+          )
         )
       )
 
@@ -218,7 +235,11 @@ class SdkScalaTypeTest {
         blob = SdkBindingDataFactory.of(blob),
         generic = SdkBindingDataFactory.of(
           SdkLiteralTypes.generics(),
-          ScalarNested("foo", "bar")
+          ScalarNested(
+            "foo",
+            Some("bar"),
+            Some(ScalarNestedNested("foo", Some("bar")))
+          )
         )
       )
 
@@ -245,7 +266,15 @@ class SdkScalaTypeTest {
           Struct.of(
             Map(
               "foo" -> Struct.Value.ofStringValue("foo"),
-              "bar" -> Struct.Value.ofStringValue("bar")
+              "bar" -> Struct.Value.ofStringValue("bar"),
+              "nestedNested" -> Struct.Value.ofStructValue(
+                Struct.of(
+                  Map(
+                    "foo" -> Struct.Value.ofStringValue("foo"),
+                    "bar" -> Struct.Value.ofStringValue("bar")
+                  ).asJava
+                )
+              )
             ).asJava
           )
         )
@@ -285,7 +314,11 @@ class SdkScalaTypeTest {
       blob = SdkBindingDataFactory.of(blob),
       generic = SdkBindingDataFactory.of(
         SdkLiteralTypes.generics(),
-        ScalarNested("foo", "bar")
+        ScalarNested(
+          "foo",
+          Some("bar"),
+          Some(ScalarNestedNested("foo", Some("bar")))
+        )
       )
     )
 
@@ -301,7 +334,11 @@ class SdkScalaTypeTest {
       "blob" -> SdkBindingDataFactory.of(blob),
       "generic" -> SdkBindingDataFactory.of(
         SdkLiteralTypes.generics[ScalarNested](),
-        ScalarNested("foo", "bar")
+        ScalarNested(
+          "foo",
+          Some("bar"),
+          Some(ScalarNestedNested("foo", Some("bar")))
+        )
       )
     ).asJava
 

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
@@ -308,7 +308,7 @@ object SdkLiteralTypes {
           value.asInstanceOf[Double].toLong
         } else if (tpe =:= typeOf[Float]) {
           value.asInstanceOf[Double].toFloat
-        } else if (tpe <:< typeOf[Option[Any]]) { // this has to be before Product check
+        } else if (tpe <:< typeOf[Option[Any]]) { // this has to be before Product check because Option is a Product
           Some(
             valueToParamValue(
               value,

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
@@ -309,12 +309,16 @@ object SdkLiteralTypes {
         } else if (tpe =:= typeOf[Float]) {
           value.asInstanceOf[Double].toFloat
         } else if (tpe <:< typeOf[Option[Any]]) { // this has to be before Product check because Option is a Product
-          Some(
-            valueToParamValue(
-              value,
-              tpe.dealias.typeArgs.head
+          if (value == None) { // None is used to represent Struct.Value.Kind.NULL_VALUE when converting struct to map
+            None
+          } else {
+            Some(
+              valueToParamValue(
+                value,
+                tpe.dealias.typeArgs.head
+              )
             )
-          )
+          }
         } else if (tpe <:< typeOf[Product]) {
           val typeTag = createTypeTag(tpe)
           val classTag = ClassTag(


### PR DESCRIPTION
# TL;DR
Handle Scala `Option` correctly by using correct type.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
For case classes like:
```scala
case class ScalarNested(
    foo: String,
    bar: Option[String],
    nestedNested: Option[ScalarNestedNested]
)
case class ScalarNestedNested(foo: String, bar: Option[String])
```
the current code doesn't handle typing correctly because calling `param.typeSignature.dealias.typeArgs.head.typeSymbol` on `Option` type does not give what we need, and it should be `param.typeSignature.dealias.typeArgs.head` instead.

Also we are not handling nested `Option` correctly, although in practice there is no good reason to define `Option[Option[String]]`.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
