### PR TITLE
Fix nested list & map of structs using case classes

### DIFF
--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkScalaTypeTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkScalaTypeTest.scala
@@ -52,7 +52,9 @@ import org.flyte.flytekitscala.SdkLiteralTypes.{
 case class ScalarNested(
     foo: String,
     bar: Option[String],
-    nestedNested: Option[ScalarNestedNested]
+    nestedNested: Option[ScalarNestedNested],
+    nestedNestedList: List[ScalarNestedNested],
+    nestedNestedMap: Map[String, ScalarNestedNested]
 )
 case class ScalarNestedNested(foo: String, bar: Option[String])
 
@@ -191,6 +193,32 @@ class SdkScalaTypeTest {
                     "bar" -> Struct.Value.ofStringValue("bar")
                   ).asJava
                 )
+              ),
+              "nestedNestedList" -> Struct.Value.ofListValue(
+                List(
+                  Struct.Value.ofStructValue(
+                    Struct.of(
+                      Map(
+                        "foo" -> Struct.Value.ofStringValue("foo"),
+                        "bar" -> Struct.Value.ofStringValue("bar")
+                      ).asJava
+                    )
+                  )
+                ).asJava
+              ),
+              "nestedNestedMap" -> Struct.Value.ofStructValue(
+                Struct.of(
+                  Map(
+                    "foo" -> Struct.Value.ofStructValue(
+                      Struct.of(
+                        Map(
+                          "foo" -> Struct.Value.ofStringValue("foo"),
+                          "bar" -> Struct.Value.ofStringValue("bar")
+                        ).asJava
+                      )
+                    )
+                  ).asJava
+                )
               )
             ).asJava
           )
@@ -212,7 +240,9 @@ class SdkScalaTypeTest {
           ScalarNested(
             "foo",
             None,
-            Some(ScalarNestedNested("foo", Some("bar")))
+            Some(ScalarNestedNested("foo", Some("bar"))),
+            List(ScalarNestedNested("foo", Some("bar"))),
+            Map("foo" -> ScalarNestedNested("foo", Some("bar")))
           )
         )
       )
@@ -238,7 +268,9 @@ class SdkScalaTypeTest {
           ScalarNested(
             "foo",
             Some("bar"),
-            Some(ScalarNestedNested("foo", Some("bar")))
+            Some(ScalarNestedNested("foo", Some("bar"))),
+            List(ScalarNestedNested("foo", Some("bar"))),
+            Map("foo" -> ScalarNestedNested("foo", Some("bar")))
           )
         )
       )
@@ -272,6 +304,32 @@ class SdkScalaTypeTest {
                   Map(
                     "foo" -> Struct.Value.ofStringValue("foo"),
                     "bar" -> Struct.Value.ofStringValue("bar")
+                  ).asJava
+                )
+              ),
+              "nestedNestedList" -> Struct.Value.ofListValue(
+                List(
+                  Struct.Value.ofStructValue(
+                    Struct.of(
+                      Map(
+                        "foo" -> Struct.Value.ofStringValue("foo"),
+                        "bar" -> Struct.Value.ofStringValue("bar")
+                      ).asJava
+                    )
+                  )
+                ).asJava
+              ),
+              "nestedNestedMap" -> Struct.Value.ofStructValue(
+                Struct.of(
+                  Map(
+                    "foo" -> Struct.Value.ofStructValue(
+                      Struct.of(
+                        Map(
+                          "foo" -> Struct.Value.ofStringValue("foo"),
+                          "bar" -> Struct.Value.ofStringValue("bar")
+                        ).asJava
+                      )
+                    )
                   ).asJava
                 )
               )
@@ -317,7 +375,9 @@ class SdkScalaTypeTest {
         ScalarNested(
           "foo",
           Some("bar"),
-          Some(ScalarNestedNested("foo", Some("bar")))
+          Some(ScalarNestedNested("foo", Some("bar"))),
+          List(ScalarNestedNested("foo", Some("bar"))),
+          Map("foo" -> ScalarNestedNested("foo", Some("bar")))
         )
       )
     )
@@ -337,7 +397,9 @@ class SdkScalaTypeTest {
         ScalarNested(
           "foo",
           Some("bar"),
-          Some(ScalarNestedNested("foo", Some("bar")))
+          Some(ScalarNestedNested("foo", Some("bar"))),
+          List(ScalarNestedNested("foo", Some("bar"))),
+          Map("foo" -> ScalarNestedNested("foo", Some("bar")))
         )
       )
     ).asJava

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
@@ -317,7 +317,6 @@ object SdkLiteralTypes {
         } else if (tpe <:< typeOf[Map[String, Any]]) {
           value
             .asInstanceOf[Map[String, Any]]
-            .view
             .mapValues(v => {
               valueToParamValue(v, tpe.typeArgs(1))
             })

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
@@ -311,15 +311,15 @@ object SdkLiteralTypes {
         } else if (tpe <:< typeOf[List[Any]]) {
           value
             .asInstanceOf[List[Any]]
-            .map(value => {
-              valueToParamValue(value, tpe.typeArgs.head)
+            .map(v => {
+              valueToParamValue(v, tpe.typeArgs.head)
             })
         } else if (tpe <:< typeOf[Map[String, Any]]) {
           value
             .asInstanceOf[Map[String, Any]]
             .view
-            .mapValues(value => {
-              valueToParamValue(value, tpe.typeArgs(1))
+            .mapValues(v => {
+              valueToParamValue(v, tpe.typeArgs(1))
             })
             .toMap
         } else if (tpe <:< typeOf[Option[Any]]) { // this has to be before Product check because Option is a Product

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
@@ -308,6 +308,20 @@ object SdkLiteralTypes {
           value.asInstanceOf[Double].toLong
         } else if (tpe =:= typeOf[Float]) {
           value.asInstanceOf[Double].toFloat
+        } else if (tpe <:< typeOf[List[Any]]) {
+          value
+            .asInstanceOf[List[Any]]
+            .map(value => {
+              valueToParamValue(value, tpe.typeArgs.head)
+            })
+        } else if (tpe <:< typeOf[Map[String, Any]]) {
+          value
+            .asInstanceOf[Map[String, Any]]
+            .view
+            .mapValues(value => {
+              valueToParamValue(value, tpe.typeArgs(1))
+            })
+            .toMap
         } else if (tpe <:< typeOf[Option[Any]]) { // this has to be before Product check because Option is a Product
           if (value == None) { // None is used to represent Struct.Value.Kind.NULL_VALUE when converting struct to map
             None


### PR DESCRIPTION
# TL;DR
Fix nested list of structs using scala layer.

```scala
case class ScalarNested(
    foo: String,
    bar: Option[String],
    nestedNested: Option[ScalarNestedNested],
    nestedNestedList: List[ScalarNestedNested], // <----- THIS
    nestedNestedMap: Map[String, ScalarNestedNested] // <----- THIS
)
case class ScalarNestedNested(foo: String, bar: Option[String])
```



support-nested-list-of-structs

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

