### PR TITLE
Escape $ inside the task name

### DIFF
--- a/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ProjectClosure.java
+++ b/jflyte-utils/src/main/java/org/flyte/jflyte/utils/ProjectClosure.java
@@ -28,6 +28,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.escape.Escaper;
+import com.google.common.escape.Escapers;
 import com.google.protobuf.ByteString;
 import java.io.File;
 import java.io.IOException;
@@ -91,6 +93,8 @@ public abstract class ProjectClosure {
   public abstract Map<WorkflowIdentifier, WorkflowSpec> workflowSpecs();
 
   public abstract Map<LaunchPlanIdentifier, LaunchPlan> launchPlans();
+
+  private static final Escaper ESCAPER = Escapers.builder().addEscape('$', "\\$").build();
 
   ProjectClosure applyCustom(JFlyteCustom custom) {
     Map<TaskIdentifier, TaskSpec> rewrittenTaskSpecs =
@@ -483,7 +487,7 @@ public abstract class ProjectClosure {
                     "jflyte",
                     "execute",
                     "--task",
-                    task.getName(),
+                    ESCAPER.escape(task.getName()),
                     "--inputs",
                     "{{.input}}",
                     "--outputPrefix",

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProjectClosureTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProjectClosureTest.java
@@ -447,7 +447,6 @@ public class ProjectClosureTest {
     // given
     RunnableTask task = createRunnableTask("NameWith$AsTaskName", null, List.of());
     String image = "my-image";
-    Resources expectedResources = Resources.builder().build();
 
     // when
     TaskTemplate result = ProjectClosure.createTaskTemplateForRunnableTask(task, image);

--- a/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProjectClosureTest.java
+++ b/jflyte-utils/src/test/java/org/flyte/jflyte/utils/ProjectClosureTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -442,6 +443,21 @@ public class ProjectClosureTest {
   }
 
   @Test
+  public void testCreateTaskTemplateForRunnableTaskWith$Name() {
+    // given
+    RunnableTask task = createRunnableTask("NameWith$AsTaskName", null, List.of());
+    String image = "my-image";
+    Resources expectedResources = Resources.builder().build();
+
+    // when
+    TaskTemplate result = ProjectClosure.createTaskTemplateForRunnableTask(task, image);
+
+    // then
+    assertTrue(
+        result.container().args().stream().anyMatch(s -> s.contains("NameWith\\$AsTaskName")));
+  }
+
+  @Test
   public void testCreateTaskTemplateForRunnableTaskWithResources() {
     // given
     Resources expectedResources =
@@ -758,10 +774,15 @@ public class ProjectClosureTest {
 
   private RunnableTask createRunnableTask(
       Resources expectedResources, List<String> customJavaToolOptions) {
+    return createRunnableTask("my-test-task", expectedResources, customJavaToolOptions);
+  }
+
+  private RunnableTask createRunnableTask(
+      String name, Resources expectedResources, List<String> customJavaToolOptions) {
     return new RunnableTask() {
       @Override
       public String getName() {
-        return "my-test-task";
+        return name;
       }
 
       @Override


### PR DESCRIPTION
# TL;DR
Escape `$` from the task name. Normally task name is generated from the className and if the className is inside and scala object the result is `ObjectName$TaskName`, so we need to scape the `$` to can execute the tasks properly.

Tested:
![Screenshot 2024-02-02 at 12 55 17](https://github.com/flyteorg/flytekit-java/assets/4025771/9f00f83e-74dd-4dd2-afcc-58cf34ef8f9f)

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
