### PR TITLE
Add support to Binary input/output type

### DIFF
--- a/flytekit-api/src/main/java/org/flyte/api/v1/Binary.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Binary.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020-2021 Flyte Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.api.v1;
+
+import com.google.auto.value.AutoValue;
+
+/**
+ * A simple byte array with a tag to help different parts of the system communicate about what is in
+ * the byte array. It's strongly advisable that consumers of this type define a unique tag and
+ * validate the tag before parsing the data.
+ */
+@AutoValue
+public abstract class Binary {
+  public static final String TAG_FIELD = "tag";
+  public static final String VALUE_FIELD = "value";
+
+  public abstract byte[] value();
+
+  public abstract String tag();
+
+  public static Builder builder() {
+    return new AutoValue_Binary.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder value(byte[] value);
+
+    public abstract Builder tag(String tag);
+
+    public abstract Binary build();
+  }
+}

--- a/flytekit-api/src/main/java/org/flyte/api/v1/Scalar.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/Scalar.java
@@ -25,7 +25,8 @@ public abstract class Scalar {
   public enum Kind {
     PRIMITIVE,
     GENERIC,
-    BLOB
+    BLOB,
+    BINARY
   }
 
   public abstract Kind kind();
@@ -35,6 +36,8 @@ public abstract class Scalar {
   public abstract Struct generic();
 
   public abstract Blob blob();
+
+  public abstract Binary binary();
 
   // TODO: add the rest of the cases from src/main/proto/flyteidl/core/literals.proto
 
@@ -48,5 +51,9 @@ public abstract class Scalar {
 
   public static Scalar ofBlob(Blob blob) {
     return AutoOneOf_Scalar.blob(blob);
+  }
+
+  public static Scalar ofBinary(Binary binary) {
+    return AutoOneOf_Scalar.binary(binary);
   }
 }

--- a/flytekit-api/src/main/java/org/flyte/api/v1/SimpleType.java
+++ b/flytekit-api/src/main/java/org/flyte/api/v1/SimpleType.java
@@ -24,5 +24,6 @@ public enum SimpleType {
   BOOLEAN,
   DATETIME,
   DURATION,
-  STRUCT
+  STRUCT,
+  BINARY
 }

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/VariableMapVisitor.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/VariableMapVisitor.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.flyte.api.v1.Binary;
 import org.flyte.api.v1.Blob;
 import org.flyte.api.v1.BlobType;
 import org.flyte.api.v1.Variable;
@@ -172,6 +173,8 @@ class VariableMapVisitor extends JsonObjectFormatVisitor.Base {
       // feature
       // https://docs.flyte.org/projects/flytekit/en/latest/generated/flytekit.BlobType.html#flytekit-blobtype
       return SdkLiteralTypes.blobs(BlobType.DEFAULT);
+    } else if (Binary.class.isAssignableFrom(type)) {
+      return SdkLiteralTypes.binary();
     }
     try {
       return JacksonSdkLiteralType.of(type);

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/BinarySerializer.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/BinarySerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020-2023 Flyte Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.flyte.flytekit.jackson.serializers;
+
+import static org.flyte.flytekit.jackson.serializers.SdkBindingDataSerializationProtocol.VALUE;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.util.Base64;
+import org.flyte.api.v1.Binary;
+import org.flyte.api.v1.Literal;
+import org.flyte.api.v1.LiteralType;
+import org.flyte.api.v1.Scalar.Kind;
+
+public class BinarySerializer extends ScalarSerializer {
+  public BinarySerializer(
+      JsonGenerator gen,
+      String key,
+      Literal value,
+      SerializerProvider serializerProvider,
+      LiteralType literalType) {
+    super(gen, key, value, serializerProvider, literalType);
+  }
+
+  @Override
+  void serializeScalar() throws IOException {
+    gen.writeObject(Kind.BINARY);
+    gen.writeFieldName(VALUE);
+    gen.writeStartObject();
+    gen.writeFieldName(Binary.TAG_FIELD);
+    gen.writeString(value.scalar().binary().tag());
+    gen.writeFieldName(Binary.VALUE_FIELD);
+    gen.writeString(Base64.getEncoder().encodeToString(value.scalar().binary().value()));
+    gen.writeEndObject();
+  }
+}

--- a/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralSerializerFactory.java
+++ b/flytekit-jackson/src/main/java/org/flyte/flytekit/jackson/serializers/LiteralSerializerFactory.java
@@ -52,6 +52,8 @@ public class LiteralSerializerFactory {
         return new GenericSerializer(gen, key, value, serializerProvider, literalType);
       case BLOB:
         return new BlobSerializer(gen, key, value, serializerProvider, literalType);
+      case BINARY:
+        return new BinarySerializer(gen, key, value, serializerProvider, literalType);
     }
     throw new AssertionError("Unexpected Literal.Kind: [" + value.scalar().kind() + "]");
   }

--- a/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkTypeTest.java
+++ b/flytekit-jackson/src/test/java/org/flyte/flytekit/jackson/JacksonSdkTypeTest.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.util.StdConverter;
 import com.google.auto.value.AutoValue;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import org.flyte.api.v1.Binary;
 import org.flyte.api.v1.Blob;
 import org.flyte.api.v1.BlobMetadata;
 import org.flyte.api.v1.BlobType;
@@ -64,6 +66,12 @@ public class JacksonSdkTypeTest {
           .uri("file://test")
           .build();
 
+  private static final Binary BINARY =
+      Binary.builder()
+          .tag("this-is-a-custom-tag")
+          .value("file://test".getBytes(StandardCharsets.UTF_8))
+          .build();
+
   public static AutoValueInput createAutoValueInput(
       long i,
       double f,
@@ -72,12 +80,15 @@ public class JacksonSdkTypeTest {
       Instant t,
       Duration d,
       Blob blob,
+      Binary binary,
       Nested generic,
       List<String> l,
       List<Blob> lb,
+      List<Binary> lbinary,
       List<Nested> lg,
       Map<String, String> m,
       Map<String, Blob> mb,
+      Map<String, Binary> mbinary,
       Map<String, Nested> mg,
       List<List<String>> ll,
       List<Map<String, String>> lm,
@@ -91,12 +102,15 @@ public class JacksonSdkTypeTest {
         SdkBindingDataFactory.of(t),
         SdkBindingDataFactory.of(d),
         SdkBindingDataFactory.of(blob),
+        SdkBindingDataFactory.of(binary),
         SdkBindingDataFactory.of(JacksonSdkLiteralType.of(Nested.class), generic),
         SdkBindingDataFactory.ofStringCollection(l),
         SdkBindingDataFactory.of(SdkLiteralTypes.blobs(BLOB_TYPE), lb),
+        SdkBindingDataFactory.of(SdkLiteralTypes.binary(), lbinary),
         SdkBindingDataFactory.of(JacksonSdkLiteralType.of(Nested.class), lg),
         SdkBindingDataFactory.ofStringMap(m),
         SdkBindingDataFactory.of(SdkLiteralTypes.blobs(BLOB_TYPE), mb),
+        SdkBindingDataFactory.of(SdkLiteralTypes.binary(), mbinary),
         SdkBindingDataFactory.of(JacksonSdkLiteralType.of(Nested.class), mg),
         SdkBindingDataFactory.of(SdkLiteralTypes.collections(SdkLiteralTypes.strings()), ll),
         SdkBindingDataFactory.of(SdkLiteralTypes.maps(SdkLiteralTypes.strings()), lm),
@@ -146,6 +160,7 @@ public class JacksonSdkTypeTest {
     literalMap.put("t", literalOf(Primitive.ofDatetime(datetime)));
     literalMap.put("d", literalOf(Primitive.ofDuration(duration)));
     literalMap.put("blob", literalOf(BLOB));
+    literalMap.put("binary", literalOf(BINARY));
     literalMap.put(
         "generic",
         literalOf(
@@ -157,12 +172,14 @@ public class JacksonSdkTypeTest {
                     Value.ofStringValue("world")))));
     literalMap.put("l", Literal.ofCollection(List.of(literalOf(Primitive.ofStringValue("123")))));
     literalMap.put("lb", Literal.ofCollection(List.of(literalOf(BLOB))));
+    literalMap.put("lbinary", Literal.ofCollection(List.of(literalOf(BINARY))));
     literalMap.put(
         "lg",
         Literal.ofCollection(
             List.of(literalOf(Struct.of(Map.of("hello", Value.ofStringValue("hello")))))));
     literalMap.put("m", Literal.ofMap(Map.of("marco", literalOf(Primitive.ofStringValue("polo")))));
     literalMap.put("mb", Literal.ofMap(Map.of("blob", literalOf(BLOB))));
+    literalMap.put("mbinary", Literal.ofMap(Map.of("binary", literalOf(BINARY))));
     literalMap.put(
         "mg",
         Literal.ofMap(
@@ -210,12 +227,15 @@ public class JacksonSdkTypeTest {
                 /* t= */ datetime,
                 /* d= */ duration,
                 /* blob= */ BLOB,
+                /* binary= */ BINARY,
                 /* generic= */ Nested.create("hello", "world"),
                 /* l= */ List.of("123"),
                 /* lb= */ List.of(BLOB),
+                /* lbinary= */ List.of(BINARY),
                 /* lg= */ List.of(Nested.create("hello")),
                 /* m= */ Map.of("marco", "polo"),
                 /* mb= */ Map.of("blob", BLOB),
+                /* mbinary= */ Map.of("binary", BINARY),
                 /* mg= */ Map.of("generic", Nested.create("hello")),
                 /* ll= */ List.of(List.of("foo", "bar"), List.of("a", "b", "c")),
                 /* lm= */ List.of(Map.of("A", "a", "B", "b"), Map.of("a", "A", "b", "B")),
@@ -244,12 +264,15 @@ public class JacksonSdkTypeTest {
                     /* t= */ Instant.ofEpochSecond(42, 1),
                     /* d= */ Duration.ofSeconds(1, 42),
                     /* blob= */ BLOB,
+                    /* binary= */ BINARY,
                     /* generic= */ Nested.create("hello"),
                     /* l= */ List.of("foo"),
                     /* lb= */ List.of(BLOB),
+                    /* lbinary= */ List.of(BINARY),
                     /* lg= */ List.of(Nested.create("hello")),
                     /* m= */ Map.of("marco", "polo"),
                     /* mb= */ Map.of("blob", BLOB),
+                    /* mbinary= */ Map.of("binary", BINARY),
                     /* mg= */ Map.of("generic", Nested.create("hello")),
                     /* ll= */ List.of(List.of("foo", "bar"), List.of("a", "b", "c")),
                     /* lm= */ List.of(Map.of("A", "a", "B", "b"), Map.of("a", "A", "b", "B")),
@@ -311,7 +334,8 @@ public class JacksonSdkTypeTest {
                                     "pi", stringLiteralOf("3.14"), "e", stringLiteralOf("2.72"))),
                             "pokemon",
                             Literal.ofMap(Map.of("ash", stringLiteralOf("pikachu")))))),
-                hasEntry("blob", literalOf(BLOB)))));
+                hasEntry("blob", literalOf(BLOB)),
+                hasEntry("binary", literalOf(BINARY)))));
   }
 
   @Test
@@ -325,12 +349,15 @@ public class JacksonSdkTypeTest {
             /* t= */ Instant.ofEpochSecond(42, 1),
             /* d= */ Duration.ofSeconds(1, 42),
             /* blob= */ BLOB,
+            /* binary= */ BINARY,
             /* generic= */ Nested.create("hello"),
             /* l= */ List.of("foo"),
             /* lb= */ List.of(BLOB),
+            /* lbinary= */ List.of(BINARY),
             /* lg= */ List.of(Nested.create("hello")),
             /* m= */ Map.of("marco", "polo"),
             /* mb= */ Map.of("blob", BLOB),
+            /* mbinary= */ Map.of("binary", BINARY),
             /* mg= */ Map.of("generic", Nested.create("hello")),
             /* ll= */ List.of(List.of("foo", "bar"), List.of("a", "b", "c")),
             /* lm= */ List.of(Map.of("A", "a", "B", "b"), Map.of("a", "A", "b", "B")),
@@ -349,12 +376,15 @@ public class JacksonSdkTypeTest {
     expected.put("t", input.t());
     expected.put("d", input.d());
     expected.put("blob", input.blob());
+    expected.put("binary", input.binary());
     expected.put("generic", input.generic());
     expected.put("l", input.l());
     expected.put("lb", input.lb());
+    expected.put("lbinary", input.lbinary());
     expected.put("lg", input.lg());
     expected.put("m", input.m());
     expected.put("mb", input.mb());
+    expected.put("mbinary", input.mbinary());
     expected.put("mg", input.mg());
     expected.put("ll", input.ll());
     expected.put("lm", input.lm());
@@ -578,17 +608,23 @@ public class JacksonSdkTypeTest {
 
     public abstract SdkBindingData<Blob> blob();
 
+    public abstract SdkBindingData<Binary> binary();
+
     public abstract SdkBindingData<Nested> generic();
 
     public abstract SdkBindingData<List<String>> l();
 
     public abstract SdkBindingData<List<Blob>> lb();
 
+    public abstract SdkBindingData<List<Binary>> lbinary();
+
     public abstract SdkBindingData<List<Nested>> lg();
 
     public abstract SdkBindingData<Map<String, String>> m();
 
     public abstract SdkBindingData<Map<String, Blob>> mb();
+
+    public abstract SdkBindingData<Map<String, Binary>> mbinary();
 
     public abstract SdkBindingData<Map<String, Nested>> mg();
 
@@ -608,19 +644,23 @@ public class JacksonSdkTypeTest {
         SdkBindingData<Instant> t,
         SdkBindingData<Duration> d,
         SdkBindingData<Blob> blob,
+        SdkBindingData<Binary> binary,
         SdkBindingData<Nested> generic,
         SdkBindingData<List<String>> l,
         SdkBindingData<List<Blob>> lb,
+        SdkBindingData<List<Binary>> lbinary,
         SdkBindingData<List<Nested>> lg,
         SdkBindingData<Map<String, String>> m,
         SdkBindingData<Map<String, Blob>> mb,
+        SdkBindingData<Map<String, Binary>> mbinary,
         SdkBindingData<Map<String, Nested>> mg,
         SdkBindingData<List<List<String>>> ll,
         SdkBindingData<List<Map<String, String>>> lm,
         SdkBindingData<Map<String, List<String>>> ml,
         SdkBindingData<Map<String, Map<String, String>>> mm) {
       return new AutoValue_JacksonSdkTypeTest_AutoValueInput(
-          i, f, s, b, t, d, blob, generic, l, lb, lg, m, mb, mg, ll, lm, ml, mm);
+          i, f, s, b, t, d, blob, binary, generic, l, lb, lbinary, lg, m, mb, mbinary, mg, ll, lm,
+          ml, mm);
     }
   }
 
@@ -725,6 +765,10 @@ public class JacksonSdkTypeTest {
 
   private static Literal literalOf(Blob blob) {
     return Literal.ofScalar(Scalar.ofBlob(blob));
+  }
+
+  private static Literal literalOf(Binary binary) {
+    return Literal.ofScalar(Scalar.ofBinary(binary));
   }
 
   private static Literal literalOf(Struct generic) {

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingDataFactory.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkBindingDataFactory.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import org.flyte.api.v1.Binary;
 import org.flyte.api.v1.Blob;
 
 /** A utility class for creating {@link SdkBindingData} objects for different types. */
@@ -133,6 +134,16 @@ public final class SdkBindingDataFactory {
    */
   public static <T> SdkBindingData<T> of(SdkLiteralType<T> type, T value) {
     return SdkBindingData.literal(type, value);
+  }
+
+  /**
+   * Creates a {@code SdkBindingData} for a flyte Binary with the given value.
+   *
+   * @param value the simple value for this data
+   * @return the new {@code SdkBindingData}
+   */
+  public static SdkBindingData<Binary> of(Binary value) {
+    return SdkBindingData.literal(SdkLiteralTypes.binary(), value);
   }
 
   /**

--- a/flytekit-java/src/main/java/org/flyte/flytekit/SdkLiteralTypes.java
+++ b/flytekit-java/src/main/java/org/flyte/flytekit/SdkLiteralTypes.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.flyte.api.v1.Binary;
 import org.flyte.api.v1.BindingData;
 import org.flyte.api.v1.Blob;
 import org.flyte.api.v1.BlobType;
@@ -31,6 +32,7 @@ import org.flyte.api.v1.Literal;
 import org.flyte.api.v1.LiteralType;
 import org.flyte.api.v1.Primitive;
 import org.flyte.api.v1.Scalar;
+import org.flyte.api.v1.SimpleType;
 
 /** A utility class for creating {@link SdkLiteralType} objects for different types. */
 public class SdkLiteralTypes {
@@ -184,6 +186,15 @@ public class SdkLiteralTypes {
   }
 
   /**
+   * Returns a {@link SdkLiteralType} for binary.
+   *
+   * @return the {@link SdkLiteralType}
+   */
+  public static SdkLiteralType<Binary> binary() {
+    return BinarySdkLiteralType.INSTANCE;
+  }
+
+  /**
    * Returns a {@link SdkLiteralType} for blobs.
    *
    * @return the {@link SdkLiteralType}
@@ -213,6 +224,30 @@ public class SdkLiteralTypes {
     @Override
     public String toString() {
       return "integers";
+    }
+  }
+
+  private static class BinarySdkLiteralType extends SdkLiteralType<Binary> {
+    private static final BinarySdkLiteralType INSTANCE = new BinarySdkLiteralType();
+
+    @Override
+    public LiteralType getLiteralType() {
+      return LiteralType.ofSimpleType(SimpleType.BINARY);
+    }
+
+    @Override
+    public final Literal toLiteral(Binary value) {
+      return Literal.ofScalar(Scalar.ofBinary(value));
+    }
+
+    @Override
+    public final Binary fromLiteral(Literal literal) {
+      return literal.scalar().binary();
+    }
+
+    @Override
+    public final BindingData toBindingData(Binary value) {
+      return BindingData.ofScalar(Scalar.ofBinary(value));
     }
   }
 

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkLiteralTypesTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkLiteralTypesTest.scala
@@ -16,8 +16,7 @@
  */
 package org.flyte.flytekitscala
 
-import org.flyte.api.v1.{Blob, BlobType}
-import org.flyte.api.v1.BlobType.BlobDimensionality
+import org.flyte.api.v1.{Binary, Blob, BlobType}
 import org.flyte.flytekit.SdkLiteralType
 import org.flyte.flytekitscala.SdkLiteralTypes.{of, _}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
@@ -67,6 +66,7 @@ class TestOfReturnsProperTypeProvider extends ArgumentsProvider {
       Arguments.of(datetimes(), of[Instant]()),
       Arguments.of(durations(), of[Duration]()),
       Arguments.of(blobs(BlobType.DEFAULT), of[Blob]()),
+      Arguments.of(binary(), of[Binary]()),
       Arguments.of(generics(), of[ScalarNested]()),
       Arguments.of(collections(integers()), of[List[Long]]()),
       Arguments.of(collections(floats()), of[List[Double]]()),

--- a/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkScalaTypeTest.scala
+++ b/flytekit-scala-tests/src/test/scala/org/flyte/flytekitscala/SdkScalaTypeTest.scala
@@ -36,14 +36,12 @@ import org.flyte.flytekit.{
   SdkBindingData,
   SdkBindingDataFactory => SdkJavaBindingDataFactory
 }
-import org.flyte.flytekitscala.SdkBindingDataFactory
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
 import org.junit.jupiter.api.Test
 import org.flyte.examples.AllInputsTask.{AutoAllInputsInput, Nested}
 import org.flyte.flytekit.jackson.JacksonSdkLiteralType
 import org.flyte.flytekitscala.SdkLiteralTypes.{
   __TYPE,
-  blobs,
   collections,
   maps,
   strings

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataConverters.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataConverters.scala
@@ -174,6 +174,11 @@ object SdkBindingDataConverters {
               SdkScalaLiteralTypes.durations(),
               jf.Function.identity()
             )
+          case SimpleType.BINARY =>
+            TypeCastingResult(
+              SdkScalaLiteralTypes.binary(),
+              jf.Function.identity()
+            )
         }
       case LiteralType.Kind.BLOB_TYPE =>
         TypeCastingResult(

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataFactory.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkBindingDataFactory.scala
@@ -16,7 +16,7 @@
  */
 package org.flyte.flytekitscala
 
-import org.flyte.api.v1.Blob
+import org.flyte.api.v1.{Binary, Blob}
 import org.flyte.flytekit.{
   BindingCollection,
   BindingMap,
@@ -144,6 +144,16 @@ object SdkBindingDataFactory {
     */
   def of(value: Blob): SdkBindingData[Blob] =
     SdkBindingData.literal(SdkLiteralTypes.blobs(value.metadata.`type`), value)
+
+  /** Creates a [[SdkBindingData]] for a flyte Binary with the given value.
+    *
+    * @param value
+    *   the simple value for this data
+    * @return
+    *   the new [[SdkBindingData]]
+    */
+  def of(value: Binary): SdkBindingData[Binary] =
+    SdkBindingData.literal(SdkLiteralTypes.binary(), value)
 
   /** Creates a [[SdkBindingData]] for a flyte type with the given value.
     *

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkLiteralTypes.scala
@@ -70,6 +70,8 @@ object SdkLiteralTypes {
         durations().asInstanceOf[SdkLiteralType[T]]
       case t if t =:= typeOf[Blob] =>
         blobs(BlobType.DEFAULT).asInstanceOf[SdkLiteralType[T]]
+      case t if t =:= typeOf[Binary] =>
+        binary().asInstanceOf[SdkLiteralType[T]]
       case t if t <:< typeOf[Product] && !(t =:= typeOf[Option[_]]) =>
         generics().asInstanceOf[SdkLiteralType[T]]
 
@@ -423,6 +425,14 @@ object SdkLiteralTypes {
 
     mapToProduct[T](structToMap(struct))
   }
+
+  /** Returns a [[SdkLiteralType]] for binary.
+    *
+    * @return
+    *   the [[SdkLiteralType]]
+    */
+  def binary(): SdkLiteralType[Binary] =
+    SdkJavaLiteralTypes.binary()
 
   /** Returns a [[SdkLiteralType]] for blob.
     *

--- a/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkScalaType.scala
+++ b/flytekit-scala_2.13/src/main/scala/org/flyte/flytekitscala/SdkScalaType.scala
@@ -248,6 +248,11 @@ object SdkScalaType {
       SdkLiteralTypes.blobs(BlobType.DEFAULT)
     )
 
+  implicit def binaryLiteralType: SdkScalaLiteralType[Binary] =
+    DelegateLiteralType(
+      SdkLiteralTypes.binary()
+    )
+
   // TODO we are forced to do this because SdkDataBinding.ofInteger returns a SdkBindingData<java.util.Long>
   //  This makes Scala dev mad when they are forced to use the java types instead of scala types
   //  We need to think what to do, maybe move the factory methods out of SdkDataBinding into their own class


### PR DESCRIPTION
# TL;DR
Add support to `Binary` scalar type.
## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Test
* Workflow
```scala
    builder.apply(
      new TestTask,
      Data(
        SdkJavaBindingDataFactory.of("testStr"),
        SdkJavaBindingDataFactory.of(Binary.builder().tag("tag").value("testBinary".getBytes()).build())
      )
    )
```

* Task
```scala
case class Data(str: SdkBindingData[String], b: SdkBindingData[Binary])
class TestTask extends SdkRunnableTask[Data, Data](SdkScalaType[Data], SdkScalaType[Data]) {
  override def run(input: Data): Data = {
    Data(
      str = SdkBindingDataFactory.of(new String(input.b.get().value())),
      b = SdkBindingDataFactory.of(
        Binary.builder().tag("tag").value(input.str.get().getBytes()).build()
      )
    )
  }
}
```
<img width="807" alt="Screenshot 2024-04-17 at 18 15 55" src="https://github.com/flyteorg/flytekit-java/assets/4025771/1e4f6b9a-ea53-4853-9b1b-445443e78a67">
<img width="816" alt="Screenshot 2024-04-17 at 18 16 02" src="https://github.com/flyteorg/flytekit-java/assets/4025771/e387f2bd-dc9c-4e1d-9772-b50141a35881">



## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
