### PR TITLE
chore: Bump CI actions/cache and checkout

### DIFF
--- a/.github/workflows/boilerplate-automation.yml
+++ b/.github/workflows/boilerplate-automation.yml
@@ -7,7 +7,7 @@ jobs:
     name: Update Boilerplate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
       - name: Update Boilerplate

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,9 +10,9 @@ jobs:
   build-snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-prepare-release-${{ hashFiles('pom.xml') }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-prepare-release-${{ hashFiles('pom.xml') }}

--- a/.github/workflows/flyteidl-automation.yml
+++ b/.github/workflows/flyteidl-automation.yml
@@ -7,7 +7,7 @@ jobs:
     name: Update flyteidl
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
       - name: Update flyteidl

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
 
       # https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-prepare-release-${{ hashFiles('pom.xml') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: flytekit-java release
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch: "0"
 


### PR DESCRIPTION
# TL;DR
Bumps deprecated `actions/cache@v2` to `actions/cache@v4`, since we're here, lets also update `actions/checkout`

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin




